### PR TITLE
Fixing SoO mission. Vloks Falls was mispelled.

### DIFF
--- a/src/missions/SoO.au3
+++ b/src/missions/SoO.au3
@@ -50,7 +50,7 @@ EndFunc
 ;~ SoO farm setup
 Func SetupSoOFarm()
 	Info('Setting up farm')
-	TravelToOutpost($ID_VLOXS_FALL, $district_name)
+	TravelToOutpost($ID_VLOXS_FALLS, $district_name)
 	TrySetupPlayerUsingGUISettings()
 	TrySetupTeamUsingGUISettings()
 	SwitchToHardModeIfEnabled()
@@ -65,7 +65,7 @@ EndFunc
 
 ;~ Run to Shards of Orr through Arbor Bay
 Func RunToShardsOfOrrDungeon()
-	TravelToOutpost($ID_VLOXS_FALL, $district_name)
+	TravelToOutpost($ID_VLOXS_FALLS, $district_name)
 	ResetFailuresCounter()
 
 	Info('Making way to portal')


### PR DESCRIPTION
Was doing some testing with some of the updates. Found this bug with SoO mission. ID_VLOKS_FALL instead of ID_VLOKS_FALLS.