### PR TITLE
LDOA District Movement Update

### DIFF
--- a/src/titles/LDOA.au3
+++ b/src/titles/LDOA.au3
@@ -369,9 +369,10 @@ Func LowHealthMonitor()
 		If $level < 10 Then
 			Notice('Health below threshold, returning to Ascalon and restarting the run.')
 			DistrictTravel($ID_ASCALON_CITY_PRESEARING, $district_name)
-		Else $level < 20 Then
+		ElseIf $level < 20 Then
 			Notice('Health below threshold, returning to Foibles and restarting the run.')
 			DistrictTravel($ID_FOIBLES_FAIR, $district_name)
+		EndIf
 		Return $SUCCESS
 	EndIf
 EndFunc


### PR DESCRIPTION
In LDOA, even when the district is explictly said it will move random into Foibles Fair. This was due to the DistrictTravel in TryTravel not taking  into account. Add this into the TryTravel and other areas it was missing in LDOA.