### PR TITLE
Optimized Boreal.au3 Chest Run

### DIFF
--- a/src/runs/Boreal.au3
+++ b/src/runs/Boreal.au3
@@ -46,6 +46,7 @@ Global Const $BOREAL_CHESTRUN_INFORMATIONS = 'For best results, have :' & @CRLF 
 	& 'Optional skills (for more survivability and unblocking): Shroud of Distress, Heart of Shadow, Deaths Charge'
 ; Average duration ~ 1m30s
 Global Const $BOREAL_FARM_DURATION = (1 * 60 + 30) * 1000
+Global Const $BOREAL_CHEST_RUN_TIMEOUT_MS = 5 * 60 * 1000
 
 ; Skill numbers declared to make the code WAY more readable (UseSkillEx($BOREAL_DWARVENSTABILITY) is better than UseSkillEx(1))
 Global Const $BOREAL_DEADLYPARADOX		= 1
@@ -272,9 +273,11 @@ EndFunc
 
 ;~ Main function for chest run
 Func BorealChestRun($X, $Y)
+	Local $runTimer = TimerInit()
 	Move($X, $Y, 0)
 	Local $me = GetMyAgent()
 	While GetDistanceToPoint($me, $X, $Y) > $RANGE_ADJACENT
+		If TimerDiff($runTimer) > $BOREAL_CHEST_RUN_TIMEOUT_MS Then Return $FAIL
 		BorealSpeedRun()
 		Sleep(250)
 		$me = GetMyAgent()


### PR DESCRIPTION
I did some optimizations of the Boreal chest run:
1. I added skillcasting behaviour when certain enemies are around: Cast Shadow Form when Mountain Pinesouls are in range. Cast I am unstoppable when Mountain Aloe are in range.
2. When the main characters health is below 60%, Shroud of Distress is a casted.
3. When the main characters health is below 20%, Heart of Shadow is casted to heal and escape.
4. Instead of returning to the original spot 2, the player now resigns earlier when all chests were opened. 
5. Added unblocking behaviour when attempting to open a chest.

Running on my Sin, the sucess rate went up from 80% to 98% on 100 runs. The time per run also went down ~10s.