### PR TITLE
fix: Increase range Aggro/PickUpItems for looting trapped areas safely

### DIFF
--- a/lib/Utils.au3
+++ b/lib/Utils.au3
@@ -915,7 +915,7 @@ EndFunc
 Func MoveAggroAndKillSafeTraps($x, $y, $log = '', $options = Null)
 	If $options = Null Then $options = CloneDictMap($Default_MoveAggroAndKill_Options)
 	$options.Item('lootTrappedArea') = True
-	$options.Item('fightRange') = $RANGE_EARSHOT
+	$options.Item('fightRange') = $RANGE_SPELLCAST
 	MoveAggroAndKill($x, $y, $log, $options)
 EndFunc
 
@@ -927,7 +927,7 @@ Func LootTrappedAreaSafely()
 	Local $y = DllStructGetData($me, 'Y')
 	CommandAll($x, $y)
 	;Add your prot spells in here if you want to
-	PickUpItems()
+	PickUpItems(Null, DefaultShouldPickItem, $RANGE_SPELLCAST)
 	RandomSleep(5000)
 	CancelAll()
 EndFunc


### PR DESCRIPTION
Increase aggro and loot range to $RANGE_SPELLCAST as I've seen bot basically ignore the reason for these functions and send team into a fiery trap of doom.