### PR TITLE
Luxon Farm - Minor Update for Oni 3

### DIFF
--- a/src/vanquishes/Luxon.au3
+++ b/src/vanquishes/Luxon.au3
@@ -192,7 +192,7 @@ Func VanquishMountQinkai()
 		[12000, 7500, 'Naga 5', $RANGE_SPIRIT], _
 		[16000, 7000, 'Naga 6', $AGGRO_RANGE], _
 		[15500, 4500, 'Leftovers', $AGGRO_RANGE], _
-		[18000, 3000, 'Oni 3', $AGGRO_RANGE], _
+		[18000, 3000, 'Oni 3', $RANGE_SPIRIT], _
 		[16500, 1000, 'Leftovers', $AGGRO_RANGE], _
 		[13500, -1500, 'Naga 7', $RANGE_SPIRIT], _
 		[12500, -3500, 'Naga 8', $RANGE_SPIRIT], _


### PR DESCRIPTION
Updating Range for Oni 3. Occasionally Agent will spawn Oni 3 but be out of agro range before the Agent can register them. Agent is still within Spirit range at the time.