### PR TITLE
feat: Add a checkbox to store items that should be kept.

### DIFF
--- a/BotsHub.au3
+++ b/BotsHub.au3
@@ -130,6 +130,7 @@ $run_options_cache['run.use_consets'] = False
 $run_options_cache['run.use_scrolls'] = False
 $run_options_cache['run.sort_items'] = False
 $run_options_cache['run.farm_materials_mid_run'] = False
+$run_options_cache['run.store_items_to_keep'] = False
 $run_options_cache['run.bags_count'] = 5
 $run_options_cache['run.donate_faction_points'] = True
 $run_options_cache['run.buy_faction_scrolls'] = False
@@ -404,6 +405,7 @@ Func ReadConfigFromJson($jsonString)
 	$run_options_cache['run.loop_mode'] = _JSON_Get($jsonObject, 'run.loop_mode')
 	$run_options_cache['run.hard_mode'] = _JSON_Get($jsonObject, 'run.hard_mode')
 	$run_options_cache['run.farm_materials_mid_run'] = _JSON_Get($jsonObject, 'run.farm_materials_mid_run')
+	$run_options_cache['run.store_items_to_keep'] = _JSON_Get($jsonObject, 'run.store_items_to_keep')
 	$run_options_cache['run.consume_consumables'] = _JSON_Get($jsonObject, 'run.consume_consumables')
 	$run_options_cache['run.use_consets'] = _JSON_Get($jsonObject, 'run.use_consets')
 	$run_options_cache['run.use_scrolls'] = _JSON_Get($jsonObject, 'run.use_scrolls')
@@ -452,6 +454,7 @@ Func WriteConfigToJson()
 	_JSON_addChangeDelete($jsonObject, 'run.loop_mode', $run_options_cache['run.loop_mode'])
 	_JSON_addChangeDelete($jsonObject, 'run.hard_mode', $run_options_cache['run.hard_mode'])
 	_JSON_addChangeDelete($jsonObject, 'run.farm_materials_mid_run', $run_options_cache['run.farm_materials_mid_run'])
+	_JSON_addChangeDelete($jsonObject, 'run.store_items_to_keep', $run_options_cache['run.store_items_to_keep'])
 	_JSON_addChangeDelete($jsonObject, 'run.consume_consumables', $run_options_cache['run.consume_consumables'])
 	_JSON_addChangeDelete($jsonObject, 'run.use_consets', $run_options_cache['run.use_consets'])
 	_JSON_addChangeDelete($jsonObject, 'run.use_scrolls', $run_options_cache['run.use_scrolls'])

--- a/lib/BotsHub-GUI.au3
+++ b/lib/BotsHub-GUI.au3
@@ -92,7 +92,7 @@ Global $gui_group_titles, _
 		$gui_label_lightbringertitle_text, $gui_label_lightbringertitle_value, $gui_label_sunspeartitle_text, $gui_label_sunspeartitle_value
 Global $gui_group_runoptions, _
 		$gui_checkbox_loopruns, $gui_checkbox_hardmode, $gui_checkbox_emergencytravel, $gui_checkbox_automaticteamsetup, $gui_checkbox_useconsumables, $gui_checkbox_useconsets, $gui_checkbox_usescrolls
-Global $gui_group_itemoptions, $gui_checkbox_sortitems, $gui_checkbox_collectdata, $gui_checkbox_salvageintocomponents, $gui_checkbox_farmmaterialsmidrun, _
+Global $gui_group_itemoptions, $gui_checkbox_sortitems, $gui_checkbox_collectdata, $gui_checkbox_salvageintocomponents, $gui_checkbox_farmmaterialsmidrun, $gui_checkbox_storeitemstokeep, _
 		$gui_label_salvagekits, $gui_combo_salvagekits, $gui_label_identificationkits, $gui_combo_identificationkits
 Global $gui_group_factionoptions, $gui_label_faction, $gui_radiobutton_donatepoints, $gui_radiobutton_buyfactionresources, $gui_radiobutton_buyfactionscrolls
 Global $gui_group_teamoptions, $gui_teamlabel, $gui_teammemberlabel, $gui_teammemberbuildlabel, _
@@ -270,23 +270,24 @@ Func CreateGUI()
 	GUICtrlSetState($gui_checkbox_emergencytravel, $GUI_DISABLE)
 	GUICtrlCreateGroup('', -99, -99, 1, 1)
 
-	$gui_group_itemoptions = GUICtrlCreateGroup('Inventory management options', 21, 205, 295, 235)
+	$gui_group_itemoptions = GUICtrlCreateGroup('Inventory management options', 21, 205, 295, 260)
 	$gui_checkbox_sortitems = GUICtrlCreateCheckbox('Sort items', 31, 225)
 	$gui_checkbox_salvageintocomponents = GUICtrlCreateCheckbox('Salvage into components', 31, 255)
 	GUICtrlSetState($gui_checkbox_salvageintocomponents, $GUI_DISABLE)
 	$gui_checkbox_farmmaterialsmidrun = GUICtrlCreateCheckbox('Salvage during run', 31, 285)
-	$gui_label_salvagekits = GUICtrlCreateLabel('Salvage kits:', 31, 318)
-	$gui_combo_salvagekits = GUICtrlCreateCombo('12', 100, 315, 40, 20, BitOR($CBS_DROPDOWNLIST, $WS_VSCROLL))
+	$gui_checkbox_storeitemstokeep = GUICtrlCreateCheckbox('Store items with components to keep', 31, 315)
+	$gui_label_salvagekits = GUICtrlCreateLabel('Salvage kits:', 31, 348)
+	$gui_combo_salvagekits = GUICtrlCreateCombo('12', 100, 342, 40, 20, BitOR($CBS_DROPDOWNLIST, $WS_VSCROLL))
 	GUICtrlSetData($gui_combo_salvagekits, $KIT_AMOUNT_CHOICE, '12')
 	GUICtrlSetState($gui_label_salvagekits, $GUI_DISABLE)
 	GUICtrlSetState($gui_combo_salvagekits, $GUI_DISABLE)
-	$gui_label_identificationkits = GUICtrlCreateLabel('Identification kits:', 160, 318)
-	$gui_combo_identificationkits = GUICtrlCreateCombo('4', 250, 315, 40, 20, BitOR($CBS_DROPDOWNLIST, $WS_VSCROLL))
+	$gui_label_identificationkits = GUICtrlCreateLabel('Identification kits:', 160, 348)
+	$gui_combo_identificationkits = GUICtrlCreateCombo('4', 250, 342, 40, 20, BitOR($CBS_DROPDOWNLIST, $WS_VSCROLL))
 	GUICtrlSetData($gui_combo_identificationkits, $KIT_AMOUNT_CHOICE, '4')
 	GUICtrlSetState($gui_label_identificationkits, $GUI_DISABLE)
 	GUICtrlSetState($gui_combo_identificationkits, $GUI_DISABLE)
-	$gui_checkbox_usescrolls = GUICtrlCreateCheckbox('Use scrolls to enter elite zones', 31, 345)
-	$gui_checkbox_collectdata = GUICtrlCreateCheckbox('Collect data into database', 31, 375)
+	$gui_checkbox_usescrolls = GUICtrlCreateCheckbox('Use scrolls to enter elite zones', 31, 375)
+	$gui_checkbox_collectdata = GUICtrlCreateCheckbox('Collect data into database', 31, 405)
 	GUICtrlCreateGroup('', -99, -99, 1, 1)
 
 	$gui_group_factionoptions = GUICtrlCreateGroup('Faction options', 330, 39, 295, 155)
@@ -303,6 +304,7 @@ Func CreateGUI()
 	GUICtrlSetBkColor($gui_renderbutton, $COLOR_YELLOW)
 
 	GUICtrlSetTip($gui_checkbox_farmmaterialsmidrun, 'Salvage items during runs to save space. Bot will take some salvage kits in inventory for that.')
+	GUICtrlSetTip($gui_checkbox_storeitemstokeep, 'Store items with components that should be kept to reduce inventory space.')
 	GUICtrlSetTip($gui_checkbox_useconsumables, 'If bot uses consumables (cake, pie, speed boosts, etc), it will do it automatically.')
 	GUICtrlSetTip($gui_checkbox_useconsets, 'If bot can use consets, it will do it automatically.')
 	GUICtrlSetTip($gui_checkbox_usescrolls, 'Automatically uses scrolls required to enter elite zones (UW, FoW, Urgoz, Deep)')
@@ -320,6 +322,7 @@ Func CreateGUI()
 	GUICtrlSetOnEvent($gui_checkbox_loopruns, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_hardmode, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_farmmaterialsmidrun, 'GuiOptionsHandler')
+	GUICtrlSetOnEvent($gui_checkbox_storeitemstokeep, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_useconsumables, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_useconsets, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_usescrolls, 'GuiOptionsHandler')
@@ -663,6 +666,8 @@ Func GuiOptionsHandler()
 			$run_options_cache['run.hard_mode'] = GUICtrlRead($gui_checkbox_hardmode) == $GUI_CHECKED
 		Case $gui_checkbox_farmmaterialsmidrun
 			$run_options_cache['run.farm_materials_mid_run'] = GUICtrlRead($gui_checkbox_farmmaterialsmidrun) == $GUI_CHECKED
+		Case $gui_checkbox_storeitemstokeep
+			$run_options_cache['run.store_items_to_keep'] = GUICtrlRead($gui_checkbox_storeitemstokeep) == $GUI_CHECKED
 		Case $gui_checkbox_useconsumables
 			$run_options_cache['run.consume_consumables'] = GUICtrlRead($gui_checkbox_useconsumables) == $GUI_CHECKED
 		Case $gui_checkbox_useconsets
@@ -1561,6 +1566,7 @@ Func ApplyConfigToGUI()
 	GUICtrlSetState($gui_checkbox_loopruns, $run_options_cache['run.loop_mode'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_hardmode, $run_options_cache['run.hard_mode'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_farmmaterialsmidrun, $run_options_cache['run.farm_materials_mid_run'] ? $GUI_CHECKED : $GUI_UNCHECKED)
+	GUICtrlSetState($gui_checkbox_storeitemstokeep, $run_options_cache['run.store_items_to_keep'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_useconsumables, $run_options_cache['run.consume_consumables'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_useconsets, $run_options_cache['run.use_consets'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_usescrolls, $run_options_cache['run.use_scrolls'] ? $GUI_CHECKED : $GUI_UNCHECKED)

--- a/lib/Utils-Storage.au3
+++ b/lib/Utils-Storage.au3
@@ -101,7 +101,7 @@ Func InventoryManagementBeforeRun($tradeTown = $ID_EYE_OF_THE_NORTH)
 			BuyRareMaterialFromMerchantUntilPoor($ID_GLOB_OF_ECTOPLASM, 10000, $ID_OBSIDIAN_SHARD)
 		EndIf
 	EndIf
-	If $cache['@store.something'] Then
+	If $cache['@store.something'] Or $run_options_cache['run.store_items_to_keep'] Then
 		If GetMapType() <> $ID_OUTPOST Then TravelToOutpost($tradeTown, $district_name)
 		StoreItemsInXunlaiStorage()
 	EndIf
@@ -508,13 +508,19 @@ Func DefaultShouldStoreItem($item)
 
 	; --------------------------------------- Weapons ---------------------------------------
 	If IsWeapon($item) Then
-		;Return ShouldKeepWeapon($item)
-		Return CheckStoreWeapon($item)
+		If ($run_options_cache['run.store_items_to_keep']) Then
+			Return ShouldKeepWeapon($item) Or CheckStoreWeapon($item)
+		Else
+			Return CheckStoreWeapon($item)
+		EndIf
 	; --------------------------------- Armor salvageables ---------------------------------
 	ElseIf isArmorSalvageItem($item) Then
 		Local $rarityName = $RARITY_NAMES_FROM_IDS[$rarity]
-		;Return ContainsValuableUpgrades($item)
-		Return $cache['Store items.Armor salvageables.' & $rarityName]
+		If ($run_options_cache['run.store_items_to_keep']) Then
+			ReturnContainsValuableUpgrades($item) Or $cache['Store items.Armor salvageables.' & $rarityName]
+		Else
+			Return $cache['Store items.Armor salvageables.' & $rarityName]
+		EndIf
 	; ------------------------------------- Consumables -------------------------------------
 	ElseIf IsConsumable($itemID) Then
 		If $quantity <> 250 Then Return False


### PR DESCRIPTION
Currently when weapons and armors have mods that we want to keep, the selling/storing logic would just keep them in inventory. This means that the bot will progressively start runs with a full inventory. This offers to store the items that contains a mod that should be kept and add a checkbox to the GUI. A better solution would be to extract the mod and store it, but I don't know how to do it.