### PR TITLE
fix:		Fixed gold balancing logic

### DIFF
--- a/lib/Utils-Storage.au3
+++ b/lib/Utils-Storage.au3
@@ -1502,18 +1502,28 @@ Func BalanceCharacterGold($goldAmount, $mode = 0)
 	Info('Balancing characters gold')
 	Local $goldCharacter = GetGoldCharacter()
 	Local $goldStorage = GetGoldStorage()
-	If $goldStorage > 950000 Then
-		Warn('Too much moneyz in Xunlai, you are a rich bitch.')
-	ElseIf $goldStorage < 50000 Then
-		Warn('Not enough moneyz in Xunlai, you poor bastard.')
-	ElseIf $goldCharacter > $goldAmount And $mode <> 1 Then
-		DepositGold($goldCharacter - $goldAmount)
-		Info('Deposited gold')
+	If $goldCharacter > $goldAmount And $mode <> 1 Then
+		; We want to deposit
+		If $goldStorage > (1000000 - ($goldCharacter - $goldAmount)) Then
+			Warn('Too much moneyz in Xunlai, you are a rich bitch.')
+		Else
+			DepositGold($goldCharacter - $goldAmount)
+			Info('Deposited gold')
+		EndIf
+		Return True
 	ElseIf $goldCharacter < $goldAmount And $mode <> 2 Then
-		WithdrawGold($goldAmount - $goldCharacter)
-		Info('Withdrawn gold')
+		; We want to withdraw
+		If $goldStorage < ($goldAmount - $goldCharacter) Then
+			Warn('Not enough moneyz in Xunlai, you poor bastard.')
+		Else
+			WithdrawGold($goldAmount - $goldCharacter)
+			Info('Withdrawn gold')
+		EndIf
+		Return True
+	Else
+		Warn('Cannot balance characters gold.')
+		Return False
 	EndIf
-	Return True
 EndFunc
 
 

--- a/lib/Utils-Storage.au3
+++ b/lib/Utils-Storage.au3
@@ -1504,19 +1504,21 @@ Func BalanceCharacterGold($goldAmount, $mode = 0)
 	Local $goldStorage = GetGoldStorage()
 	If $goldCharacter > $goldAmount And $mode <> 1 Then
 		; We want to deposit
-		If $goldStorage > (1000000 - ($goldCharacter - $goldAmount)) Then
+		Local $goldToDeposit = $goldCharacter - $goldAmount
+		If $goldStorage > (1000000 - $goldToDeposit) Then
 			Warn('Too much moneyz in Xunlai, you are a rich bitch.')
 		Else
-			DepositGold($goldCharacter - $goldAmount)
+			DepositGold($goldToDeposit)
 			Info('Deposited gold')
 		EndIf
 		Return True
 	ElseIf $goldCharacter < $goldAmount And $mode <> 2 Then
 		; We want to withdraw
-		If $goldStorage < ($goldAmount - $goldCharacter) Then
+		Local $goldToWithdraw = $goldAmount - $goldCharacter
+		If $goldStorage < ($goldToWithdraw) Then
 			Warn('Not enough moneyz in Xunlai, you poor bastard.')
 		Else
-			WithdrawGold($goldAmount - $goldCharacter)
+			WithdrawGold($goldToWithdraw)
 			Info('Withdrawn gold')
 		EndIf
 		Return True


### PR DESCRIPTION
With the previous logic, we would not deposit gold to the bank if we had no gold in the bank or not withdraw gold when there was too puch gold in the bank.