### PR TITLE
fix: Update CommandTradeInitiate

### DIFF
--- a/lib/GWA2_Assembly.au3
+++ b/lib/GWA2_Assembly.au3
@@ -1995,10 +1995,11 @@ EndFunc
 
 Func AssemblerCreateTradeCommands()
 	_('CommandTradeInitiate:')
+	_('push 0')
 	_('push dword[eax+8]')
 	_('push dword[eax+4]')
 	_('call UIMessage')
-	_('add esp,8')
+	_('add esp,C')
 	_('ljmp CommandReturn')
 
 	_('CommandTradeCancel:')


### PR DESCRIPTION
The GW patch changed the UIMessage calling convention for trade initiation. CommandTradeInitiate now pushes an extra 0 argument and stack cleanup is updated from 8 to 12 bytes accordingly. If we ever create a UIMSG_INITIATE_TRADE variable make sure we use new address 0x100001B3.