### PR TITLE
fix: Correct AddHeroByProfession logic

### DIFF
--- a/lib/Utils.au3
+++ b/lib/Utils.au3
@@ -1618,13 +1618,29 @@ EndFunc
 ;~ Try to add any available hero of the given profession to the party.
 ;~ If $preferredHeroID is specified, tries that hero first before falling back to others.
 ;~ Iterates all known heroes of that profession and attempts AddHero until one succeeds.
+;~ If a hero of that profession is already in party, returns that hero number and does not try to add.
 ;~ Returns the hero's party index (1-based) on success, or 0 if no hero of that profession could be added.
 Func AddHeroByProfession($professionID, $preferredHeroID = 0)
+	If $preferredHeroID > 0 Then
+		Local $preferredHeroNumber = GetHeroNumberByHeroID($preferredHeroID)
+		If IsNumber($preferredHeroNumber) Then Return $preferredHeroNumber
+	EndIf
+
+	For $heroNumber = 1 To GetHeroCount()
+		If GetHeroProfession($heroNumber) == $professionID Then Return $heroNumber
+	Next
+
 	If $preferredHeroID > 0 Then
 		Local $previousCount = GetHeroCount()
 		AddHero($preferredHeroID)
 		Sleep(500)
-		If GetHeroCount() > $previousCount Then Return $SUCCESS
+		If GetHeroCount() > $previousCount Then
+			Local $preferredHeroNumber = GetHeroNumberByHeroID($preferredHeroID)
+			If IsNumber($preferredHeroNumber) Then Return $preferredHeroNumber
+			For $heroNumber = 1 To GetHeroCount()
+				If GetHeroProfession($heroNumber) == $professionID Then Return $heroNumber
+			Next
+		EndIf
 	EndIf
 	For $heroID In MapKeys($HERO_PROFESSIONS)
 		If $HERO_PROFESSIONS[$heroID] <> $professionID Then ContinueLoop
@@ -1632,7 +1648,13 @@ Func AddHeroByProfession($professionID, $preferredHeroID = 0)
 		Local $previousCount = GetHeroCount()
 		AddHero($heroID)
 		Sleep(500)
-		If GetHeroCount() > $previousCount Then Return $SUCCESS
+		If GetHeroCount() > $previousCount Then
+			Local $heroNumber = GetHeroNumberByHeroID($heroID)
+			If IsNumber($heroNumber) Then Return $heroNumber
+			For $i = 1 To GetHeroCount()
+				If GetHeroProfession($i) == $professionID Then Return $i
+			Next
+		EndIf
 	Next
 	Error('Could not add any hero with profession ID ' & $professionID)
 	Return $FAIL

--- a/lib/Utils.au3
+++ b/lib/Utils.au3
@@ -1619,7 +1619,7 @@ EndFunc
 ;~ If $preferredHeroID is specified, tries that hero first before falling back to others.
 ;~ Iterates all known heroes of that profession and attempts AddHero until one succeeds.
 ;~ If a hero of that profession is already in party, returns that hero number and does not try to add.
-;~ Returns the hero's party index (1-based) on success, or 0 if no hero of that profession could be added.
+;~ Returns the hero's party index (1-based) on success, or Null if no hero of that profession could be added.
 Func AddHeroByProfession($professionID, $preferredHeroID = 0)
 	If $preferredHeroID > 0 Then
 		Local $preferredHeroNumber = GetHeroNumberByHeroID($preferredHeroID)
@@ -1657,7 +1657,7 @@ Func AddHeroByProfession($professionID, $preferredHeroID = 0)
 		EndIf
 	Next
 	Error('Could not add any hero with profession ID ' & $professionID)
-	Return $FAIL
+	Return Null
 EndFunc
 
 

--- a/src/farms/Corsairs.au3
+++ b/src/farms/Corsairs.au3
@@ -112,9 +112,14 @@ Func SetupTeamCorsairsFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
+	Local $dervishHeroNumber = Null
 	LeaveParty()
 	If AddRequiredHero($ID_DUNKORO) == $FAIL Then Return $FAIL
-	If AddHeroByProfession($ID_DERVISH, $ID_MELONNI) == $FAIL Then Return $FAIL
+	$dervishHeroNumber = AddHeroByProfession($ID_DERVISH, $ID_MELONNI)
+	If Not IsNumber($dervishHeroNumber) Then
+		Warn('Could not add dervish hero to party')
+		Return $FAIL
+	EndIf
 	LoadSkillTemplate($MOP_CORSAIRS_HERO_SKILLBAR, 1)
 	LoadSkillTemplate($DR_CORSAIRS_HERO_SKILLBAR, 2)
 	RandomSleep(250)

--- a/src/farms/Corsairs.au3
+++ b/src/farms/Corsairs.au3
@@ -64,6 +64,8 @@ Global Const $CORSAIRS_MYSTIC_HEALING	= 2
 
 Global $corsairs_farm_setup = False
 Global $bohseda_timer = Null
+Global $corsairs_dunkoro_hero_number = 1
+Global $corsairs_dervish_hero_number = 2
 
 ;~ Main method to farm Corsairs
 Func CorsairsFarm()
@@ -112,19 +114,23 @@ Func SetupTeamCorsairsFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
-	Local $dervishHeroNumber = Null
 	LeaveParty()
 	If AddRequiredHero($ID_DUNKORO) == $FAIL Then Return $FAIL
-	$dervishHeroNumber = AddHeroByProfession($ID_DERVISH, $ID_MELONNI)
-	If Not IsNumber($dervishHeroNumber) Then
+	$corsairs_dunkoro_hero_number = GetHeroNumberByHeroID($ID_DUNKORO)
+	If Not IsNumber($corsairs_dunkoro_hero_number) Then
+		Warn('Could not find Dunkoro in party')
+		Return $FAIL
+	EndIf
+	$corsairs_dervish_hero_number = AddHeroByProfession($ID_DERVISH, $ID_MELONNI)
+	If Not IsNumber($corsairs_dervish_hero_number) Then
 		Warn('Could not add dervish hero to party')
 		Return $FAIL
 	EndIf
-	LoadSkillTemplate($MOP_CORSAIRS_HERO_SKILLBAR, 1)
-	LoadSkillTemplate($DR_CORSAIRS_HERO_SKILLBAR, 2)
+	LoadSkillTemplate($MOP_CORSAIRS_HERO_SKILLBAR, $corsairs_dunkoro_hero_number)
+	LoadSkillTemplate($DR_CORSAIRS_HERO_SKILLBAR, $corsairs_dervish_hero_number)
 	RandomSleep(250)
-	DisableHeroSkillSlot(1, $CORSAIRS_MAKE_HASTE)
-	DisableHeroSkillSlot(2, $CORSAIRS_WINNOWING)
+	DisableHeroSkillSlot($corsairs_dunkoro_hero_number, $CORSAIRS_MAKE_HASTE)
+	DisableHeroSkillSlot($corsairs_dervish_hero_number, $CORSAIRS_WINNOWING)
 	RandomSleep(250)
 	Return $SUCCESS
 EndFunc
@@ -155,12 +161,12 @@ Func CorsairsFarmLoop()
 	RandomSleep(100)
 	UseSkillEx($CORSAIRS_WHIRLING_DEFENSE)
 	RandomSleep(100)
-	UseHeroSkill(1, $CORSAIRS_MAKE_HASTE, GetMyAgent())
+	UseHeroSkill($corsairs_dunkoro_hero_number, $CORSAIRS_MAKE_HASTE, GetMyAgent())
 	RandomSleep(100)
 	$bohseda_timer = TimerInit()
 	; Furthest point from Bohseda
-	CommandHero(1, -13778, -10156)
-	CommandHero(2, -10850, -7025)
+	CommandHero($corsairs_dunkoro_hero_number, -13778, -10156)
+	CommandHero($corsairs_dervish_hero_number, -10850, -7025)
 	MoveTo(-9050, -7000)
 	Local $captainBohseda = GetNearestNPCToCoords(-9850, -7250)
 	UseSkillEx($CORSAIRS_HEART_OF_SHADOW, $captainBohseda)
@@ -180,10 +186,10 @@ Func CorsairsFarmLoop()
 	UseSkillEx($CORSAIRS_HEART_OF_SHADOW, GetNearestEnemyToAgent(GetMyAgent()))
 	DefendAgainstCorsairs()
 
-	UseHeroSkill(2, $CORSAIRS_WINNOWING)
+	UseHeroSkill($corsairs_dervish_hero_number, $CORSAIRS_WINNOWING)
 	MoveTo(-9783,-7073, 0, 0)
 	WaitForBohseda()
-	CommandHero(2, -13778, -10156)
+	CommandHero($corsairs_dervish_hero_number, -13778, -10156)
 	UseSkillEx($CORSAIRS_DWARVEN_STABILITY)
 	RandomSleep(50)
 	CastAllDefensiveSkills()

--- a/src/farms/FoWTowerOfCourage.au3
+++ b/src/farms/FoWTowerOfCourage.au3
@@ -123,11 +123,21 @@ EndFunc
 ;~ Fissure of Woe - Tower of Courage farm setup
 Func SetupFoWToCFarm()
 	Info('Setting up farm')
+	Local $monkHeroNumber = Null
+	Local $paragonHeroNumber = Null
 	If TravelToFoWOutpost($district_name) == $FAIL Then Return $FAIL
 	SwitchMode($ID_NORMAL_MODE)
 	LeaveParty()
-	If AddHeroByProfession($ID_MONK, $ID_OGDEN) == $FAIL Then Return $FAIL
-	If AddHeroByProfession($ID_PARAGON, $ID_GENERAL_MORGAHN) == $FAIL Then Return $FAIL
+	$monkHeroNumber = AddHeroByProfession($ID_MONK, $ID_OGDEN)
+	If Not IsNumber($monkHeroNumber) Then
+		Warn('Could not add monk hero to party')
+		Return $FAIL
+	EndIf
+	$paragonHeroNumber = AddHeroByProfession($ID_PARAGON, $ID_GENERAL_MORGAHN)
+	If Not IsNumber($paragonHeroNumber) Then
+		Warn('Could not add paragon hero to party')
+		Return $FAIL
+	EndIf
 	If SetupPlayerFoWToCFarm() == $FAIL Then Return $FAIL
 	If SetupTeamFoWToCFarm() == $FAIL Then Return $FAIL
 	$fow_toc_farm_setup = True

--- a/src/farms/FoWTowerOfCourage.au3
+++ b/src/farms/FoWTowerOfCourage.au3
@@ -105,6 +105,8 @@ Global Const $FOW_TOC_MODELID_ABYSSAL			= 2861
 
 Global $fow_toc_farm_setup = False
 Global $fow_toc_30s_timer
+Global $fow_toc_monk_hero_number = 1
+Global $fow_toc_paragon_hero_number = 2
 
 ;~ Main method to farm Fissure of Woe - Tower of Courage
 Func FoWToCFarm()
@@ -123,18 +125,16 @@ EndFunc
 ;~ Fissure of Woe - Tower of Courage farm setup
 Func SetupFoWToCFarm()
 	Info('Setting up farm')
-	Local $monkHeroNumber = Null
-	Local $paragonHeroNumber = Null
 	If TravelToFoWOutpost($district_name) == $FAIL Then Return $FAIL
 	SwitchMode($ID_NORMAL_MODE)
 	LeaveParty()
-	$monkHeroNumber = AddHeroByProfession($ID_MONK, $ID_OGDEN)
-	If Not IsNumber($monkHeroNumber) Then
+	$fow_toc_monk_hero_number = AddHeroByProfession($ID_MONK, $ID_OGDEN)
+	If Not IsNumber($fow_toc_monk_hero_number) Then
 		Warn('Could not add monk hero to party')
 		Return $FAIL
 	EndIf
-	$paragonHeroNumber = AddHeroByProfession($ID_PARAGON, $ID_GENERAL_MORGAHN)
-	If Not IsNumber($paragonHeroNumber) Then
+	$fow_toc_paragon_hero_number = AddHeroByProfession($ID_PARAGON, $ID_GENERAL_MORGAHN)
+	If Not IsNumber($fow_toc_paragon_hero_number) Then
 		Warn('Could not add paragon hero to party')
 		Return $FAIL
 	EndIf
@@ -161,11 +161,11 @@ EndFunc
 
 Func SetupTeamFoWToCFarm()
 	Info('Setting up team build skill bars')
-	LoadSkillTemplate($FOW_TOC_M_HERO_SKILLBAR, 1)
-	LoadSkillTemplate($FOW_TOC_P_HERO_SKILLBAR, 2)
+	LoadSkillTemplate($FOW_TOC_M_HERO_SKILLBAR, $fow_toc_monk_hero_number)
+	LoadSkillTemplate($FOW_TOC_P_HERO_SKILLBAR, $fow_toc_paragon_hero_number)
 	RandomSleep(250)
-	DisableAllHeroSkills(1)
-	DisableAllHeroSkills(2)
+	DisableAllHeroSkills($fow_toc_monk_hero_number)
+	DisableAllHeroSkills($fow_toc_paragon_hero_number)
 	Return $SUCCESS
 EndFunc
 
@@ -308,20 +308,20 @@ Func HeroesCastFoWToCBuffs()
 	Local $myAgent = GetMyAgent()
 	CommandAll(-23300, -1300)
 	RandomSleep(1200)
-	UseHeroSkill(1, $FOW_TOC_DIVINE_SPIRIT)
-	UseHeroSkill(2, $FOW_TOC_VOCAL_WAS_SOGOLON)
+	UseHeroSkill($fow_toc_monk_hero_number, $FOW_TOC_DIVINE_SPIRIT)
+	UseHeroSkill($fow_toc_paragon_hero_number, $FOW_TOC_VOCAL_WAS_SOGOLON)
 	RandomSleep(1200)
-	UseHeroSkill(1, $FOW_TOC_BLESSED_AURA)
-	UseHeroSkill(2, $FOW_TOC_ENDURING_HARMONY, $myAgent)
+	UseHeroSkill($fow_toc_monk_hero_number, $FOW_TOC_BLESSED_AURA)
+	UseHeroSkill($fow_toc_paragon_hero_number, $FOW_TOC_ENDURING_HARMONY, $myAgent)
 	RandomSleep(2400)
-	UseHeroSkill(1, $FOW_TOC_SPELLBREAKER, $myAgent)
-	UseHeroSkill(2, $FOW_TOC_BRACE_YOURSELVES, $myAgent)
+	UseHeroSkill($fow_toc_monk_hero_number, $FOW_TOC_SPELLBREAKER, $myAgent)
+	UseHeroSkill($fow_toc_paragon_hero_number, $FOW_TOC_BRACE_YOURSELVES, $myAgent)
 	RandomSleep(1200)
-	UseHeroSkill(2, $FOW_TOC_STAND_YOUR_GROUND)
+	UseHeroSkill($fow_toc_paragon_hero_number, $FOW_TOC_STAND_YOUR_GROUND)
 	RandomSleep(50)
-	UseHeroSkill(2, $FOW_TOC_INCOMING)
+	UseHeroSkill($fow_toc_paragon_hero_number, $FOW_TOC_INCOMING)
 	RandomSleep(50)
-	UseHeroSkill(2, $FOW_TOC_BLADETURN_REFRAIN, $myAgent)
+	UseHeroSkill($fow_toc_paragon_hero_number, $FOW_TOC_BLADETURN_REFRAIN, $myAgent)
 EndFunc
 
 

--- a/src/farms/GemstoneMargonite.au3
+++ b/src/farms/GemstoneMargonite.au3
@@ -189,8 +189,13 @@ Func SetupTeamMargoniteFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
+	Local $monkHeroNumber = Null
 	LeaveParty()
-	If AddHeroByProfession($ID_MONK, $MARGONITE_HERO_PARTY_ID) == $FAIL Then Return $FAIL
+	$monkHeroNumber = AddHeroByProfession($ID_MONK, $MARGONITE_HERO_PARTY_ID)
+	If Not IsNumber($monkHeroNumber) Then
+		Warn('Could not add monk hero to party')
+		Return $FAIL
+	EndIf
 	RandomSleep(500)
 	If GetPartySize() <> 2 Then
 		Warn('Could not add monk hero to team. Team size different than 2')

--- a/src/farms/GemstoneMargonite.au3
+++ b/src/farms/GemstoneMargonite.au3
@@ -120,6 +120,7 @@ Global $margonite_aura_of_restoration_timer	= TimerInit()
 
 Global $margonite_player_profession = $ID_MESMER
 Global $gemstone_margonite_farm_setup = False
+Global $margonite_monk_hero_number = 1
 
 ;~ Main loop function for farming margonite gemstones
 Func GemstoneMargoniteFarm()
@@ -131,7 +132,7 @@ Func GemstoneMargoniteFarm()
 		Info('Successfully cleared margonite mobs')
 	ElseIf $result == $FAIL Then
 		If IsPlayerDead() Then Warn('Player died')
-		If IsHeroDead(1) Then Warn('monk hero died')
+		If IsHeroDead($margonite_monk_hero_number) Then Warn('monk hero died')
 		Info('Could not clear margonite mobs')
 	EndIf
 	Info('Returning back to the outpost')
@@ -189,10 +190,9 @@ Func SetupTeamMargoniteFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
-	Local $monkHeroNumber = Null
 	LeaveParty()
-	$monkHeroNumber = AddHeroByProfession($ID_MONK, $MARGONITE_HERO_PARTY_ID)
-	If Not IsNumber($monkHeroNumber) Then
+	$margonite_monk_hero_number = AddHeroByProfession($ID_MONK, $MARGONITE_HERO_PARTY_ID)
+	If Not IsNumber($margonite_monk_hero_number) Then
 		Warn('Could not add monk hero to party')
 		Return $FAIL
 	EndIf
@@ -203,20 +203,20 @@ Func SetupTeamMargoniteFarm()
 	EndIf
 	RandomSleep(250)
 	Info('Setting up hero build skill bar')
-	LoadSkillTemplate($MARGONITE_MONK_HERO_SKILLBAR, 1)
+	LoadSkillTemplate($MARGONITE_MONK_HERO_SKILLBAR, $margonite_monk_hero_number)
 	RandomSleep(250)
-	SetHeroBehaviour(1, $ID_HERO_AVOIDING)
+	SetHeroBehaviour($margonite_monk_hero_number, $ID_HERO_AVOIDING)
 	RandomSleep(250)
-	DisableAllHeroSkills(1)
+	DisableAllHeroSkills($margonite_monk_hero_number)
 	RandomSleep(250)
 	Return $SUCCESS
 EndFunc
 
 
 Func EnableMargoniteHeroSkills()
-	EnableHeroSkillSlot(1, $MARGONITE_HERO_BLESSED_SIGNET)
+	EnableHeroSkillSlot($margonite_monk_hero_number, $MARGONITE_HERO_BLESSED_SIGNET)
 	Sleep(25 + GetPing())
-	EnableHeroSkillSlot(1, $MARGONITE_HERO_TROLL_UNGUENT)
+	EnableHeroSkillSlot($margonite_monk_hero_number, $MARGONITE_HERO_TROLL_UNGUENT)
 	Sleep(25 + GetPing())
 EndFunc
 
@@ -249,28 +249,28 @@ Func CastBondsMargoniteFarm()
 	; Below sequence ensures that player have the effect of 5 monk enchantments from monk hero and also monk hero have 1 enchantment - balthazar's spirit
 	; Last 2 enchantments are least important so these may deactivate when hero energy drops to 0, which is unlikely
 	; Disable blessed signet hero skill so that hero does not mess up below sequence with using that skill in wrong moment
-	DisableHeroSkillSlot(1, $MARGONITE_HERO_BLESSED_SIGNET)
+	DisableHeroSkillSlot($margonite_monk_hero_number, $MARGONITE_HERO_BLESSED_SIGNET)
 	Sleep(25 + GetPing())
 
-	UseHeroSkillTimed(1, $MARGONITE_HERO_BALTHAZAR_SPIRIT, GetMyAgent())	; costs 10 energy
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_BALTHAZAR_SPIRIT, GetMyAgent())	; costs 10 energy
 	Sleep(10000)																			; wait until energy is recovered, should recover 10 energy with 3 energy pips
-	UseHeroSkillTimed(1, $MARGONITE_HERO_WATCHFUL_SPIRIT, GetMyAgent())	; costs 15 energy
-	UseHeroSkillTimed(1, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 6 hero energy
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_WATCHFUL_SPIRIT, GetMyAgent())	; costs 15 energy
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 6 hero energy
 	Sleep(12000)																			; wait until Blessed signet is recharged, should recover 8 energy with 2 energy pips
-	UseHeroSkillTimed(1, $MARGONITE_HERO_LIFE_BARRIER, GetMyAgent())		; costs 15 energy, 1 energy should be recovered during casting, energy should be maxed
-	UseHeroSkillTimed(1, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 9 hero energy
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_LIFE_BARRIER, GetMyAgent())		; costs 15 energy, 1 energy should be recovered during casting, energy should be maxed
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 9 hero energy
 	Sleep(15000)																			; wait until Blessed signet is recharged, should recover 5 energy with 1 energy pip
-	UseHeroSkillTimed(1, $MARGONITE_HERO_LIFE_BOND, GetMyAgent())			; costs 10 energy
-	UseHeroSkillTimed(1, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 11 hero energy, energy should be maxed
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_LIFE_BOND, GetMyAgent())			; costs 10 energy
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 11 hero energy, energy should be maxed
 	Sleep(10000)																			; wait until Blessed signet is recharged, 0 pips
-	UseHeroSkillTimed(1, $MARGONITE_HERO_VITAL_BLESSING, GetMyAgent())		; costs 10 energy
-	UseHeroSkillTimed(1, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 11 hero energy
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_VITAL_BLESSING, GetMyAgent())		; costs 10 energy
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 11 hero energy
 	Sleep(10000)																			; wait until Blessed signet is recharged, around 3 energy lost with -1 pip
-	UseHeroSkillTimed(1, $MARGONITE_HERO_BALTHAZAR_SPIRIT)					; costs 10 energy
-	UseHeroSkillTimed(1, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 11 hero energy, -2 pips, but energy will be recovered soon with balthazar's spirit
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_BALTHAZAR_SPIRIT)					; costs 10 energy
+	UseHeroSkillTimed($margonite_monk_hero_number, $MARGONITE_HERO_BLESSED_SIGNET)					; recover 11 hero energy, -2 pips, but energy will be recovered soon with balthazar's spirit
 
 	; Enable blessed signet skill so that hero uses it whenever it is recharged
-	EnableHeroSkillSlot(1, $MARGONITE_HERO_BLESSED_SIGNET)
+	EnableHeroSkillSlot($margonite_monk_hero_number, $MARGONITE_HERO_BLESSED_SIGNET)
 	Sleep(25 + GetPing())
 
 	Return $SUCCESS
@@ -317,7 +317,7 @@ Func GemstoneMargoniteFarmLoop()
 	If MargoniteMoveDefending(-11410, -11359) == $FAIL Then Return $FAIL
 	WaitAggroMargonites(3000)
 	If MargoniteMoveDefending(-11484, -11034) == $FAIL Then Return $FAIL
-	If IsPlayerDead() Or IsHeroDead(1) Then Return $FAIL
+	If IsPlayerDead() Or IsHeroDead($margonite_monk_hero_number) Then Return $FAIL
 
 	; if margonites group is somehow not in the spot then try to get closer to them
 	; getting closer to nearest Anur Dabi or Kaya or Ki or Su, not nearest Vu, Ruk, Tuk
@@ -392,11 +392,11 @@ EndFunc
 
 
 Func MargoniteMonkHeroHeal()
-	Local $monkHero = GetAgentByID(GetHeroID(1))
-	If IsRecharged($MARGONITE_HERO_TROLL_UNGUENT, 1) And _
+	Local $monkHero = GetAgentByID(GetHeroID($margonite_monk_hero_number))
+	If IsRecharged($MARGONITE_HERO_TROLL_UNGUENT, $margonite_monk_hero_number) And _
 			GetEnergy($monkHero) > 10 And DllStructGetData($monkHero, 'HealthPercent') < 1 And _
-			GetEffect($ID_TROLL_UNGUENT, 1) == Null Then
-		UseHeroSkill(1, $MARGONITE_HERO_TROLL_UNGUENT)
+			GetEffect($ID_TROLL_UNGUENT, $margonite_monk_hero_number) == Null Then
+		UseHeroSkill($margonite_monk_hero_number, $MARGONITE_HERO_TROLL_UNGUENT)
 	EndIf
 EndFunc
 
@@ -472,7 +472,7 @@ EndFunc
 
 Func KillMargonites()
 	Info('Fighting margonites')
-	UseHeroSkill(1, $MARGONITE_HERO_EDGE_OF_EXTINCTION)
+	UseHeroSkill($margonite_monk_hero_number, $MARGONITE_HERO_EDGE_OF_EXTINCTION)
 	Switch $margonite_player_profession
 		Case $ID_ASSASSIN, $ID_MESMER, $ID_ELEMENTALIST
 			KillMargonitesUsingVisageSkills()
@@ -488,7 +488,7 @@ Func KillMargonitesUsingVisageSkills()
 	Local $timerKill = TimerInit()
 	Local Static $maxFightTime = 100000
 
-	While CountFoesInRangeOfAgent(GetMyAgent(), $MARGONITES_RANGE) > 0 And TimerDiff($timerKill) < $maxFightTime And Not IsHeroDead(1)
+	While CountFoesInRangeOfAgent(GetMyAgent(), $MARGONITES_RANGE) > 0 And TimerDiff($timerKill) < $maxFightTime And Not IsHeroDead($margonite_monk_hero_number)
 		RandomSleep(100)
 		MargoniteDefend()
 
@@ -525,7 +525,7 @@ Func KillMargonitesUsingWhirlingDefense()
 	Local $timerKill = TimerInit()
 	Local Static $maxFightTime = 100000
 
-	While CountFoesInRangeOfAgent(GetMyAgent(), $MARGONITES_RANGE) > 0 And TimerDiff($timerKill) < $maxFightTime And Not IsHeroDead(1)
+	While CountFoesInRangeOfAgent(GetMyAgent(), $MARGONITES_RANGE) > 0 And TimerDiff($timerKill) < $maxFightTime And Not IsHeroDead($margonite_monk_hero_number)
 		RandomSleep(100)
 		MargoniteDefend()
 

--- a/src/farms/GemstoneStygian.au3
+++ b/src/farms/GemstoneStygian.au3
@@ -155,9 +155,14 @@ Func SetupTeamStygianFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
+	Local $rangerHeroNumber = Null
 	LeaveParty()
 	If DllStructGetData(GetMyAgent(), 'Primary') == $ID_RANGER Then
-		If AddHeroByProfession($ID_RANGER, $STYGIAN_HERO_PARTY_ID) == $FAIL Then Return $FAIL
+		$rangerHeroNumber = AddHeroByProfession($ID_RANGER, $STYGIAN_HERO_PARTY_ID)
+		If Not IsNumber($rangerHeroNumber) Then
+			Warn('Could not add ranger hero to party')
+			Return $FAIL
+		EndIf
 		RandomSleep(500)
 		LoadSkillTemplate($STYGIAN_RANGER_HERO_SKILLBAR, 1)
 		RandomSleep(500)

--- a/src/farms/GemstoneStygian.au3
+++ b/src/farms/GemstoneStygian.au3
@@ -97,6 +97,7 @@ $stygian_run_options.Item('openChests')			= False
 
 Global $stygian_player_profession = $ID_MESMER
 Global $gemstone_stygian_farm_setup = False
+Global $stygian_ranger_hero_number = 1
 
 ;~ Main loop function for farming stygian gemstones
 Func GemstoneStygianFarm()
@@ -155,20 +156,19 @@ Func SetupTeamStygianFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
-	Local $rangerHeroNumber = Null
 	LeaveParty()
 	If DllStructGetData(GetMyAgent(), 'Primary') == $ID_RANGER Then
-		$rangerHeroNumber = AddHeroByProfession($ID_RANGER, $STYGIAN_HERO_PARTY_ID)
-		If Not IsNumber($rangerHeroNumber) Then
+		$stygian_ranger_hero_number = AddHeroByProfession($ID_RANGER, $STYGIAN_HERO_PARTY_ID)
+		If Not IsNumber($stygian_ranger_hero_number) Then
 			Warn('Could not add ranger hero to party')
 			Return $FAIL
 		EndIf
 		RandomSleep(500)
-		LoadSkillTemplate($STYGIAN_RANGER_HERO_SKILLBAR, 1)
+		LoadSkillTemplate($STYGIAN_RANGER_HERO_SKILLBAR, $stygian_ranger_hero_number)
 		RandomSleep(500)
-		SetHeroBehaviour(1, $ID_HERO_AVOIDING)
+		SetHeroBehaviour($stygian_ranger_hero_number, $ID_HERO_AVOIDING)
 		RandomSleep(500)
-		DisableAllHeroSkills(1)
+		DisableAllHeroSkills($stygian_ranger_hero_number)
 		If GetPartySize() <> 2 Then
 			Warn('Could not add ranger hero to team. Team size different than 2')
 			Return $FAIL
@@ -256,7 +256,7 @@ Func StygianFarmRanger()
 	MoveTo(9900, -5200)
 	If IsPlayerDead() Then Return $FAIL
 	RandomSleep(7500)
-	UseHeroSkill(1, $STYGIAN_HERO_SUCCOR, GetMyAgent())
+	UseHeroSkill($stygian_ranger_hero_number, $STYGIAN_HERO_SUCCOR, GetMyAgent())
 	RandomSleep(7500)
 	CancelAll()
 	If StygianJobRanger() == $FAIL Then Return $FAIL
@@ -338,9 +338,9 @@ Func StygianJobRanger()
 	UseSkillEx($STYGIAN_RANGER_SPIKE_TRAP)
 	UseSkillEx($STYGIAN_RANGER_FLAME_TRAP)
 	; 36	-	Speed at 3.5	Dust at 10.5	Spike at 13.5
-	UseHeroSkill(1, $STYGIAN_HERO_LACERATE)
+	UseHeroSkill($stygian_ranger_hero_number, $STYGIAN_HERO_LACERATE)
 	Sleep(10500)
-	UseHeroSkill(1, $STYGIAN_HERO_EDGE_OF_EXTINCTION)
+	UseHeroSkill($stygian_ranger_hero_number, $STYGIAN_HERO_EDGE_OF_EXTINCTION)
 	; 46.5	-	Speed up		Dust up			Spike at 3
 	UseSkillEx($STYGIAN_RANGER_TRAPPERS_SPEED)
 	UseSkillEx($STYGIAN_RANGER_DUST_TRAP)
@@ -351,7 +351,7 @@ Func StygianJobRanger()
 	UseSkillEx($STYGIAN_RANGER_FLAME_TRAP)
 	; 52.5	-	Speed at 14		Dust at 18		Spike at 13.5
 	;Sleep(14000)
-	UseHeroSkill(1, $STYGIAN_HERO_BRAMBLES)
+	UseHeroSkill($stygian_ranger_hero_number, $STYGIAN_HERO_BRAMBLES)
 	UseSkillEx($STYGIAN_RANGER_WINNOWING)
 	CommandAll(9900, -5200)
 	UseSkillEx($STYGIAN_RANGER_MUDDY_TERRAIN)
@@ -442,7 +442,7 @@ Func GoToHidingSpot()
 	; waiting for mobs to run by
 	RandomSleep(7500)
 	If $stygian_player_profession == $ID_RANGER Then
-		UseHeroSkill(1, $STYGIAN_HERO_SUCCOR, GetMyAgent())
+		UseHeroSkill($stygian_ranger_hero_number, $STYGIAN_HERO_SUCCOR, GetMyAgent())
 	EndIf
 	RandomSleep(7500)
 	RunStygianFarm(10575, -8170)

--- a/src/farms/JadeBrotherhood.au3
+++ b/src/farms/JadeBrotherhood.au3
@@ -121,8 +121,13 @@ Func SetupTeamJadeBrotherhoodFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
+	Local $paragonHeroNumber = Null
 	LeaveParty()
-	If AddHeroByProfession($ID_PARAGON, $JB_HERO_PARTY_ID) == $FAIL Then Return $FAIL
+	$paragonHeroNumber = AddHeroByProfession($ID_PARAGON, $JB_HERO_PARTY_ID)
+	If Not IsNumber($paragonHeroNumber) Then
+		Warn('Could not add paragon hero to party')
+		Return $FAIL
+	EndIf
 	RandomSleep(250)
 	LoadSkillTemplate($JB_HERO_SKILLBAR, 1)
 	RandomSleep(250)

--- a/src/farms/JadeBrotherhood.au3
+++ b/src/farms/JadeBrotherhood.au3
@@ -70,6 +70,7 @@ Global Const $JB_TIMEOUT = 120000
 
 Global $jade_brotherhood_farm_setup = False
 Global $deadlock_timer
+Global $jade_brotherhood_paragon_hero_number = 1
 
 
 ;~ Main method to farm Jade Brotherhood for q8
@@ -93,7 +94,7 @@ Func SetupJadeBrotherhoodFarm()
 
 	GoToBukdekByway()
 	RandomSleep(50)
-	UseHeroSkill(1, $BROTHERHOOD_INCOMING)
+	UseHeroSkill($jade_brotherhood_paragon_hero_number, $BROTHERHOOD_INCOMING)
 	MoveTo(-14000, -11000)
 	Move(-14000, -11700)
 	RandomSleep(1000)
@@ -121,17 +122,16 @@ Func SetupTeamJadeBrotherhoodFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
-	Local $paragonHeroNumber = Null
 	LeaveParty()
-	$paragonHeroNumber = AddHeroByProfession($ID_PARAGON, $JB_HERO_PARTY_ID)
-	If Not IsNumber($paragonHeroNumber) Then
+	$jade_brotherhood_paragon_hero_number = AddHeroByProfession($ID_PARAGON, $JB_HERO_PARTY_ID)
+	If Not IsNumber($jade_brotherhood_paragon_hero_number) Then
 		Warn('Could not add paragon hero to party')
 		Return $FAIL
 	EndIf
 	RandomSleep(250)
-	LoadSkillTemplate($JB_HERO_SKILLBAR, 1)
+	LoadSkillTemplate($JB_HERO_SKILLBAR, $jade_brotherhood_paragon_hero_number)
 	RandomSleep(250)
-	DisableAllHeroSkills(1)
+	DisableAllHeroSkills($jade_brotherhood_paragon_hero_number)
 	RandomSleep(500)
 	If GetPartySize() <> 2 Then
 		Warn('Could not set up party correctly. Team size different than 2')
@@ -180,16 +180,16 @@ EndFunc
 ;~ Separate from paragon hero - you'll be missed Morgahn
 Func MoveToSeparationWithHero()
 	Info('Moving to crossing')
-	UseHeroSkill(1, $BROTHERHOOD_VOCAL_WAS_SOGOLON)
+	UseHeroSkill($jade_brotherhood_paragon_hero_number, $BROTHERHOOD_VOCAL_WAS_SOGOLON)
 	RandomSleep(1250)
-	UseHeroSkill(1, $BROTHERHOOD_INCOMING)
+	UseHeroSkill($jade_brotherhood_paragon_hero_number, $BROTHERHOOD_INCOMING)
 	RandomSleep(50)
 	MoveTo(-10475, -9685)
-	UseHeroSkill(1, $BROTHERHOOD_FALLBACK)
+	UseHeroSkill($jade_brotherhood_paragon_hero_number, $BROTHERHOOD_FALLBACK)
 	MoveTo(-11303, -6545)
 	CommandAll(-11303, -6545)
 	MoveTo(-11983, -6261)
-	UseHeroSkill(1, $BROTHERHOOD_MAKE_HASTE, GetMyAgent())
+	UseHeroSkill($jade_brotherhood_paragon_hero_number, $BROTHERHOOD_MAKE_HASTE, GetMyAgent())
 EndFunc
 
 #CS
@@ -247,15 +247,15 @@ Func KillJadeBrotherhood()
 	Local $target
 
 	Info('Clearing Jade Brotherhood')
-	UseHeroSkill(1, $BROTHERHOOD_INCOMING)
+	UseHeroSkill($jade_brotherhood_paragon_hero_number, $BROTHERHOOD_INCOMING)
 	UseSkillEx($JB_DRUNKENMASTER)
 	RandomSleep(50)
-	UseHeroSkill(1, $BROTHERHOOD_STAND_YOUR_GROUND)
+	UseHeroSkill($jade_brotherhood_paragon_hero_number, $BROTHERHOOD_STAND_YOUR_GROUND)
 	RandomSleep(50)
-	UseHeroSkill(1, $BROTHERHOOD_ENDURING_HARMONY, GetMyAgent())
+	UseHeroSkill($jade_brotherhood_paragon_hero_number, $BROTHERHOOD_ENDURING_HARMONY, GetMyAgent())
 	UseSkillEx($JB_SAND_SHARDS)
 	RandomSleep(50)
-	UseHeroSkill(1, $BROTHERHOOD_BLADETURN_REFRAIN, GetMyAgent())
+	UseHeroSkill($jade_brotherhood_paragon_hero_number, $BROTHERHOOD_BLADETURN_REFRAIN, GetMyAgent())
 
 	$target = GetNearestEnemyToCoords(-13262, -5486)
 	Local $center = FindMiddleOfFoes(DllStructGetData($target, 'X'), DllStructGetData($target, 'Y'), 2 * $RANGE_EARSHOT)

--- a/src/farms/Kournans.au3
+++ b/src/farms/Kournans.au3
@@ -131,10 +131,25 @@ Func SetupTeamKournansFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
+	Local $rangerHeroNumber = Null
+	Local $ritualistHeroNumber = Null
+	Local $paragonHeroNumber = Null
 	LeaveParty()
-	If AddHeroByProfession($ID_RANGER, $KOURNANS_RANGER_HERO) == $FAIL Then Return $FAIL
-	If AddHeroByProfession($ID_RITUALIST, $KOURNANS_RITUALIST_HERO) == $FAIL Then Return $FAIL
-	If AddHeroByProfession($ID_PARAGON, $KOURNANS_PARAGON_HERO) == $FAIL Then Return $FAIL
+	$rangerHeroNumber = AddHeroByProfession($ID_RANGER, $KOURNANS_RANGER_HERO)
+	If Not IsNumber($rangerHeroNumber) Then
+		Warn('Could not add ranger hero to party')
+		Return $FAIL
+	EndIf
+	$ritualistHeroNumber = AddHeroByProfession($ID_RITUALIST, $KOURNANS_RITUALIST_HERO)
+	If Not IsNumber($ritualistHeroNumber) Then
+		Warn('Could not add ritualist hero to party')
+		Return $FAIL
+	EndIf
+	$paragonHeroNumber = AddHeroByProfession($ID_PARAGON, $KOURNANS_PARAGON_HERO)
+	If Not IsNumber($paragonHeroNumber) Then
+		Warn('Could not add paragon hero to party')
+		Return $FAIL
+	EndIf
 	RandomSleep(500)
 	If GetPartySize() <> 4 Then
 		Warn('Could not set up party correctly. Team size different than 4')

--- a/src/farms/Kournans.au3
+++ b/src/farms/Kournans.au3
@@ -80,6 +80,9 @@ Global Const $KOURNANS_VITAL_WEAPON			= 3
 Global Const $KOURNANS_DEATH_PACT_SIGNET	= 4
 
 Global $kournans_farm_setup = False
+Global $kournans_ranger_hero_number = 1
+Global $kournans_ritualist_hero_number = 2
+Global $kournans_paragon_hero_number = 3
 
 
 ;~ Main method to farm Kournans
@@ -131,22 +134,19 @@ Func SetupTeamKournansFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
-	Local $rangerHeroNumber = Null
-	Local $ritualistHeroNumber = Null
-	Local $paragonHeroNumber = Null
 	LeaveParty()
-	$rangerHeroNumber = AddHeroByProfession($ID_RANGER, $KOURNANS_RANGER_HERO)
-	If Not IsNumber($rangerHeroNumber) Then
+	$kournans_ranger_hero_number = AddHeroByProfession($ID_RANGER, $KOURNANS_RANGER_HERO)
+	If Not IsNumber($kournans_ranger_hero_number) Then
 		Warn('Could not add ranger hero to party')
 		Return $FAIL
 	EndIf
-	$ritualistHeroNumber = AddHeroByProfession($ID_RITUALIST, $KOURNANS_RITUALIST_HERO)
-	If Not IsNumber($ritualistHeroNumber) Then
+	$kournans_ritualist_hero_number = AddHeroByProfession($ID_RITUALIST, $KOURNANS_RITUALIST_HERO)
+	If Not IsNumber($kournans_ritualist_hero_number) Then
 		Warn('Could not add ritualist hero to party')
 		Return $FAIL
 	EndIf
-	$paragonHeroNumber = AddHeroByProfession($ID_PARAGON, $KOURNANS_PARAGON_HERO)
-	If Not IsNumber($paragonHeroNumber) Then
+	$kournans_paragon_hero_number = AddHeroByProfession($ID_PARAGON, $KOURNANS_PARAGON_HERO)
+	If Not IsNumber($kournans_paragon_hero_number) Then
 		Warn('Could not add paragon hero to party')
 		Return $FAIL
 	EndIf
@@ -155,12 +155,12 @@ Func SetupTeamKournansFarm()
 		Warn('Could not set up party correctly. Team size different than 4')
 		Return $FAIL
 	EndIf
-	LoadSkillTemplate($R_KOURNANS_HERO_SKILLBAR, $KOURNANS_RANGER_HERO_POSITION)
-	LoadSkillTemplate($RT_KOURNANS_HERO_SKILLBAR, $KOURNANS_RITUALIST_HERO_POSITION)
-	LoadSkillTemplate($P_KOURNANS_HERO_SKILLBAR, $KOURNANS_PARAGON_HERO_POSITION)
+	LoadSkillTemplate($R_KOURNANS_HERO_SKILLBAR, $kournans_ranger_hero_number)
+	LoadSkillTemplate($RT_KOURNANS_HERO_SKILLBAR, $kournans_ritualist_hero_number)
+	LoadSkillTemplate($P_KOURNANS_HERO_SKILLBAR, $kournans_paragon_hero_number)
 	RandomSleep(250)
-	DisableAllHeroSkills(1)
-	DisableAllHeroSkills(2)
+	DisableAllHeroSkills($kournans_ranger_hero_number)
+	DisableAllHeroSkills($kournans_ritualist_hero_number)
 	RandomSleep(250)
 	Return $SUCCESS
 EndFunc
@@ -236,48 +236,48 @@ EndFunc
 
 ;~ Cast the mandatory spirits and boons
 Func CastOnlyNecessarySpiritsAndBoons($safeX, $safeY)
-	UseHeroSkill($KOURNANS_RANGER_HERO_POSITION, $KOURNANS_EDGE_OF_EXTINCTION)
+	UseHeroSkill($kournans_ranger_hero_number, $KOURNANS_EDGE_OF_EXTINCTION)
 	; Get closer to the non-enemies to trigger them into enemies
 	Local $targetFoe = GetFurthestNPCInRangeOfCoords(Null, 9600, -650, $RANGE_EARSHOT)
 	GetAlmostInRangeOfAgent($targetFoe, $RANGE_EARSHOT - 50)
 	; Move back to be safe for a few seconds
 	MoveTo($safeX, $safeY)
 	RandomSleep(4000)
-	UseHeroSkill($KOURNANS_RANGER_HERO_POSITION, $KOURNANS_MUDDY_TERRAIN)
+	UseHeroSkill($kournans_ranger_hero_number, $KOURNANS_MUDDY_TERRAIN)
 	RandomSleep(6000)
-	UseHeroSkill($KOURNANS_RANGER_HERO_POSITION, $KOURNANS_BRAMBLES)
+	UseHeroSkill($kournans_ranger_hero_number, $KOURNANS_BRAMBLES)
 	RandomSleep(3000)
-	UseHeroSkill($KOURNANS_RITUALIST_HERO_POSITION, $KOURNANS_RITUAL_LORD)
-	UseHeroSkill($KOURNANS_RITUALIST_HERO_POSITION, $KOURNANS_EARTHBIND)
+	UseHeroSkill($kournans_ritualist_hero_number, $KOURNANS_RITUAL_LORD)
+	UseHeroSkill($kournans_ritualist_hero_number, $KOURNANS_EARTHBIND)
 	RandomSleep(1500)
-	UseHeroSkill($KOURNANS_RITUALIST_HERO_POSITION, $KOURNANS_VITAL_WEAPON, GetMyAgent())
+	UseHeroSkill($kournans_ritualist_hero_number, $KOURNANS_VITAL_WEAPON, GetMyAgent())
 	RandomSleep(1500)
 EndFunc
 
 
 ;~ Cast all of the spirits and boons - it is not necessary
 Func CastFullSpiritsAndBoons($safeX, $safeY)
-	UseHeroSkill($KOURNANS_RANGER_HERO_POSITION, $KOURNANS_EDGE_OF_EXTINCTION)
+	UseHeroSkill($kournans_ranger_hero_number, $KOURNANS_EDGE_OF_EXTINCTION)
 	; Get closer to the non-enemies to trigger them into enemies
 	Local $targetFoe = GetFurthestNPCInRangeOfCoords(Null, 9600, -650, $RANGE_EARSHOT)
 	GetAlmostInRangeOfAgent($targetFoe, $RANGE_EARSHOT -100)
 	; Move back to be safe for a few seconds
 	MoveTo($safeX, $safeY)
 	RandomSleep(5000)
-	UseHeroSkill($KOURNANS_RANGER_HERO_POSITION, $KOURNANS_BRAMBLES)
+	UseHeroSkill($kournans_ranger_hero_number, $KOURNANS_BRAMBLES)
 	RandomSleep(6000)
-	UseHeroSkill($KOURNANS_RANGER_HERO_POSITION, $KOURNANS_LACERATE)
+	UseHeroSkill($kournans_ranger_hero_number, $KOURNANS_LACERATE)
 	RandomSleep(4000)
-	UseHeroSkill($KOURNANS_RANGER_HERO_POSITION, $KOURNANS_NATURES_RENEWAL)
+	UseHeroSkill($kournans_ranger_hero_number, $KOURNANS_NATURES_RENEWAL)
 	RandomSleep(6000)
-	UseHeroSkill($KOURNANS_RANGER_HERO_POSITION, $KOURNANS_MUDDY_TERRAIN)
+	UseHeroSkill($kournans_ranger_hero_number, $KOURNANS_MUDDY_TERRAIN)
 	RandomSleep(6000)
-	UseHeroSkill($KOURNANS_RANGER_HERO_POSITION, $KOURNANS_PESTILENCE)
+	UseHeroSkill($kournans_ranger_hero_number, $KOURNANS_PESTILENCE)
 	RandomSleep(3000)
-	UseHeroSkill($KOURNANS_RITUALIST_HERO_POSITION, $KOURNANS_RITUAL_LORD)
-	UseHeroSkill($KOURNANS_RITUALIST_HERO_POSITION, $KOURNANS_EARTHBIND)
+	UseHeroSkill($kournans_ritualist_hero_number, $KOURNANS_RITUAL_LORD)
+	UseHeroSkill($kournans_ritualist_hero_number, $KOURNANS_EARTHBIND)
 	RandomSleep(1500)
-	UseHeroSkill($KOURNANS_RITUALIST_HERO_POSITION, $KOURNANS_VITAL_WEAPON, GetMyAgent())
+	UseHeroSkill($kournans_ritualist_hero_number, $KOURNANS_VITAL_WEAPON, GetMyAgent())
 	RandomSleep(1500)
 EndFunc
 

--- a/src/farms/Mantids.au3
+++ b/src/farms/Mantids.au3
@@ -111,8 +111,13 @@ Func SetupTeamMantidsFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
+	Local $paragonHeroNumber = Null
 	LeaveParty()
-	If AddHeroByProfession($ID_PARAGON, $ID_GENERAL_MORGAHN) == $FAIL Then Return $FAIL
+	$paragonHeroNumber = AddHeroByProfession($ID_PARAGON, $ID_GENERAL_MORGAHN)
+	If Not IsNumber($paragonHeroNumber) Then
+		Warn('Could not add paragon hero to party')
+		Return $FAIL
+	EndIf
 	LoadSkillTemplate($MANTIDS_HERO_SKILLBAR, 1)
 	RandomSleep(250)
 	DisableAllHeroSkills(1)

--- a/src/farms/Mantids.au3
+++ b/src/farms/Mantids.au3
@@ -61,6 +61,7 @@ Global Const $MANTIDS_MAKE_HASTE			= 7
 Global Const $MANTIDS_BLADETURN_REFRAIN		= 8
 
 Global $mantids_farm_setup = False
+Global $mantids_paragon_hero_number = 1
 
 
 ;~ Main method to farm Mantids
@@ -111,16 +112,15 @@ Func SetupTeamMantidsFarm()
 	If IsTeamAutoSetup() Then Return $SUCCESS
 
 	Info('Setting up team')
-	Local $paragonHeroNumber = Null
 	LeaveParty()
-	$paragonHeroNumber = AddHeroByProfession($ID_PARAGON, $ID_GENERAL_MORGAHN)
-	If Not IsNumber($paragonHeroNumber) Then
+	$mantids_paragon_hero_number = AddHeroByProfession($ID_PARAGON, $ID_GENERAL_MORGAHN)
+	If Not IsNumber($mantids_paragon_hero_number) Then
 		Warn('Could not add paragon hero to party')
 		Return $FAIL
 	EndIf
-	LoadSkillTemplate($MANTIDS_HERO_SKILLBAR, 1)
+	LoadSkillTemplate($MANTIDS_HERO_SKILLBAR, $mantids_paragon_hero_number)
 	RandomSleep(250)
-	DisableAllHeroSkills(1)
+	DisableAllHeroSkills($mantids_paragon_hero_number)
 	Return $SUCCESS
 EndFunc
 
@@ -144,25 +144,25 @@ Func MantidsFarmLoop()
 	If GetMapID() <> $ID_WAJJUN_BAZAAR Then Return $FAIL
 	Local $target
 
-	UseHeroSkill(1, $MANTIDS_VOCAL_WAS_SOGOLON)
+	UseHeroSkill($mantids_paragon_hero_number, $MANTIDS_VOCAL_WAS_SOGOLON)
 	RandomSleep(1500)
-	UseHeroSkill(1, $MANTIDS_INCOMING)
+	UseHeroSkill($mantids_paragon_hero_number, $MANTIDS_INCOMING)
 	AdlibRegister('MantidsUseFallBack', 8000)
 
 	; Move to spot before aggro
 	MoveTo(3150, -16350, 0, 0)
 	RandomSleep(1500)
-	UseHeroSkill(1, $MANTIDS_ENDURING_HARMONY, GetMyAgent())
+	UseHeroSkill($mantids_paragon_hero_number, $MANTIDS_ENDURING_HARMONY, GetMyAgent())
 	RandomSleep(1500)
-	UseHeroSkill(1, $MANTIDS_THEY_RE_ON_FIRE)
-	UseHeroSkill(1, $MANTIDS_MAKE_HASTE, GetMyAgent())
+	UseHeroSkill($mantids_paragon_hero_number, $MANTIDS_THEY_RE_ON_FIRE)
+	UseHeroSkill($mantids_paragon_hero_number, $MANTIDS_MAKE_HASTE, GetMyAgent())
 	UseSkillEx($MANTIDS_SERPENTS_QUICKNESS)
 	RandomSleep(50)
-	UseHeroSkill(1, $MANTIDS_BLADETURN_REFRAIN, GetMyAgent())
+	UseHeroSkill($mantids_paragon_hero_number, $MANTIDS_BLADETURN_REFRAIN, GetMyAgent())
 	UseSkillEx($MANTIDS_SHROUD_OF_DISTRESS)
 	RandomSleep(50)
 	UseSkillEx($MANTIDS_SHADOWFORM)
-	UseHeroSkill(1, $MANTIDS_BRACEYOURSELF, GetMyAgent())
+	UseHeroSkill($mantids_paragon_hero_number, $MANTIDS_BRACEYOURSELF, GetMyAgent())
 	RandomSleep(50)
 	CommandAll(9000, -19500)
 
@@ -231,7 +231,7 @@ EndFunc
 
 ;~ Paragon Hero uses Fallback
 Func MantidsUseFallBack()
-	UseHeroSkill(1, $MANTIDS_FALLBACK)
+	UseHeroSkill($mantids_paragon_hero_number, $MANTIDS_FALLBACK)
 	AdlibUnRegister('MantidsUseFallBack')
 EndFunc
 

--- a/src/farms/Raptors.au3
+++ b/src/farms/Raptors.au3
@@ -95,6 +95,7 @@ $raptors_move_options.Item('openChests')				= False
 
 Global $raptors_farm_setup = False
 Global $raptors_player_profession = $ID_WARRIOR
+Global $raptors_hero_number = 1
 
 ;~ Main method to farm Raptors
 Func RaptorsFarm()
@@ -150,11 +151,15 @@ Func SetupTeamRaptorsFarm()
 	Info('Setting up team')
 	RandomSleep(500)
 	LeaveParty()
-	If AddHeroByProfession($ID_PARAGON, $RAPTORS_HERO_PARTY_ID) == $FAIL Then Return $FAIL
+	$raptors_hero_number = AddHeroByProfession($ID_PARAGON, $RAPTORS_HERO_PARTY_ID)
+	If Not IsNumber($raptors_hero_number) Then
+		Warn('Could not add paragon hero to party')
+		Return $FAIL
+	EndIf
 	RandomSleep(250)
-	LoadSkillTemplate($P_RUNNER_HERO_SKILLBAR, 1)
+	LoadSkillTemplate($P_RUNNER_HERO_SKILLBAR, $raptors_hero_number)
 	RandomSleep(250)
-	DisableAllHeroSkills(1)
+	DisableAllHeroSkills($raptors_hero_number)
 	RandomSleep(500)
 	If GetPartySize() <> 2 Then
 		Warn('Could not set up party correctly. Team size different than 2')
@@ -181,9 +186,9 @@ EndFunc
 Func RaptorsFarmLoop()
 	If GetMapID() <> $ID_RIVEN_EARTH Then Return $FAIL
 
-	UseHeroSkill(1, $RAPTORS_VOCAL_WAS_SOGOLON)
+	UseHeroSkill($raptors_hero_number, $RAPTORS_VOCAL_WAS_SOGOLON)
 	RandomSleep(1200)
-	UseHeroSkill(1, $RAPTORS_INCOMING)
+	UseHeroSkill($raptors_hero_number, $RAPTORS_INCOMING)
 	GetRaptorsAsuraBlessing()
 	MoveToBaseOfCave()
 	Info('Moving Hero away')
@@ -218,20 +223,20 @@ Func MoveToBaseOfCave()
 	Info('Moving to Cave')
 	Move(-22015, -7502)
 	RandomSleep(7000)
-	UseHeroSkill(1, $RAPTORS_FALLBACK)
+	UseHeroSkill($raptors_hero_number, $RAPTORS_FALLBACK)
 	RandomSleep(500)
 	If ($raptors_player_profession == $ID_WARRIOR) Then UseSkillEx($RAPTORS_I_AM_UNSTOPPABLE)
 	Moveto(-21333, -8384)
-	UseHeroSkill(1, $RAPTORS_ENDURING_HARMONY, GetMyAgent())
+	UseHeroSkill($raptors_hero_number, $RAPTORS_ENDURING_HARMONY, GetMyAgent())
 	If ($raptors_player_profession == $ID_DERVISH) Then UseSkillEx($RAPTORS_SIGNET_OF_MYSTIC_SPEED, GetMyAgent())
 	RandomSleep(1800)
-	UseHeroSkill(1, $RAPTORS_MAKE_HASTE, GetMyAgent())
+	UseHeroSkill($raptors_hero_number, $RAPTORS_MAKE_HASTE, GetMyAgent())
 	RandomSleep(50)
-	UseHeroSkill(1, $RAPTORS_STAND_YOUR_GROUND)
+	UseHeroSkill($raptors_hero_number, $RAPTORS_STAND_YOUR_GROUND)
 	RandomSleep(50)
-	UseHeroSkill(1, $RAPTORS_CANT_TOUCH_THIS)
+	UseHeroSkill($raptors_hero_number, $RAPTORS_CANT_TOUCH_THIS)
 	RandomSleep(50)
-	UseHeroSkill(1, $RAPTORS_BLADETURN_REFRAIN, GetMyAgent())
+	UseHeroSkill($raptors_hero_number, $RAPTORS_BLADETURN_REFRAIN, GetMyAgent())
 	Move(-20930, -9480)
 EndFunc
 


### PR DESCRIPTION
Would fail when hero already persisted in party add checks for hero in function to make sure to proceed without relying on LeaveParty() as a bandaid.