### PR TITLE
Add go-offline and whisper-flash features; refactor ChatLog polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ conf/farm/*
 conf/loot/*
 !conf/farm/Default Farm Configuration.json
 !conf/loot/Default Loot Configuration.json
-.idea/
+.*/
+!.github/
+.*
+!.gitignore

--- a/BotsHub.au3
+++ b/BotsHub.au3
@@ -204,8 +204,6 @@ Func Main()
 		EndIf
 		; Authentication
 		Authentification($character_name)
-		If $run_options_cache['run.go_offline'] Then SetPlayerStatus(0)
-		If $run_options_cache['run.flash_whisper'] Then EnableWhisperFlash()
 		$runtime_status = 'RUNNING'
 	Else
 		MsgBox(0, 'Error', 'Unknown run mode: ' & $run_mode)
@@ -416,6 +414,7 @@ Func ReadConfigFromJson($jsonString)
 	$run_options_cache['run.sort_items'] = _JSON_Get($jsonObject, 'run.sort_items')
 	$run_options_cache['run.collect_data'] = _JSON_Get($jsonObject, 'run.collect_data')
 	$run_options_cache['run.go_offline'] = _JSON_Get($jsonObject, 'run.go_offline')
+	$run_options_cache['run.flash_whisper'] = _JSON_Get($jsonObject, 'run.flash_whisper')
 	$run_options_cache['run.donate_faction_points'] = _JSON_Get($jsonObject, 'run.donate_faction_points')
 	$run_options_cache['run.buy_faction_resources'] = _JSON_Get($jsonObject, 'run.buy_faction_resources')
 	$run_options_cache['run.buy_faction_scrolls'] = _JSON_Get($jsonObject, 'run.buy_faction_scrolls')
@@ -464,6 +463,7 @@ Func WriteConfigToJson()
 	_JSON_addChangeDelete($jsonObject, 'run.sort_items', $run_options_cache['run.sort_items'])
 	_JSON_addChangeDelete($jsonObject, 'run.collect_data', $run_options_cache['run.collect_data'])
 	_JSON_addChangeDelete($jsonObject, 'run.go_offline', $run_options_cache['run.go_offline'])
+	_JSON_addChangeDelete($jsonObject, 'run.flash_whisper', $run_options_cache['run.flash_whisper'])
 	_JSON_addChangeDelete($jsonObject, 'run.donate_faction_points', $run_options_cache['run.donate_faction_points'])
 	_JSON_addChangeDelete($jsonObject, 'run.buy_faction_resources', $run_options_cache['run.buy_faction_resources'])
 	_JSON_addChangeDelete($jsonObject, 'run.buy_faction_scrolls', $run_options_cache['run.buy_faction_scrolls'])
@@ -608,6 +608,10 @@ Func GeneralFarmSetup()
 		If GetMapType() <> $ID_OUTPOST Then TravelToOutpost($ID_EYE_OF_THE_NORTH)
 		SetupPlayerUsingGlobalSettings()
 		SetupTeamUsingGlobalSettings()
+	EndIf
+	If $character_name <> '' Then
+		If $run_options_cache['run.go_offline'] Then SetPlayerStatus(0)
+		If $run_options_cache['run.flash_whisper'] Then EnableWhisperFlash()
 	EndIf
 
 	SetupPlayerBuildOverrides()

--- a/BotsHub.au3
+++ b/BotsHub.au3
@@ -33,6 +33,7 @@
 #include 'lib/GWA2_ID.au3'
 #include 'lib/GWA2.au3'
 #include 'lib/GWA2_Assembly.au3'
+#include 'lib/GWA2_Assembly_Chatlog.au3'
 #include 'lib/Utils.au3'
 #include 'lib/Utils-Agents.au3'
 #include 'lib/Utils-Storage.au3'
@@ -135,6 +136,8 @@ $run_options_cache['run.donate_faction_points'] = True
 $run_options_cache['run.buy_faction_scrolls'] = False
 $run_options_cache['run.buy_faction_resources'] = False
 $run_options_cache['run.collect_data'] = False
+$run_options_cache['run.go_offline'] = False
+$run_options_cache['run.flash_whisper'] = False
 $run_options_cache['team.automatic_team_setup'] = False
 ; Overrides on $run_options_cache for frequent usage
 Global $district_name = 'Random EU'
@@ -201,6 +204,8 @@ Func Main()
 		EndIf
 		; Authentication
 		Authentification($character_name)
+		If $run_options_cache['run.go_offline'] Then SetPlayerStatus(0)
+		If $run_options_cache['run.flash_whisper'] Then EnableWhisperFlash()
 		$runtime_status = 'RUNNING'
 	Else
 		MsgBox(0, 'Error', 'Unknown run mode: ' & $run_mode)
@@ -410,6 +415,7 @@ Func ReadConfigFromJson($jsonString)
 	$run_options_cache['run.sort_items'] = _JSON_Get($jsonObject, 'run.sort_items')
 	$run_options_cache['run.sort_items'] = _JSON_Get($jsonObject, 'run.sort_items')
 	$run_options_cache['run.collect_data'] = _JSON_Get($jsonObject, 'run.collect_data')
+	$run_options_cache['run.go_offline'] = _JSON_Get($jsonObject, 'run.go_offline')
 	$run_options_cache['run.donate_faction_points'] = _JSON_Get($jsonObject, 'run.donate_faction_points')
 	$run_options_cache['run.buy_faction_resources'] = _JSON_Get($jsonObject, 'run.buy_faction_resources')
 	$run_options_cache['run.buy_faction_scrolls'] = _JSON_Get($jsonObject, 'run.buy_faction_scrolls')
@@ -457,6 +463,7 @@ Func WriteConfigToJson()
 	_JSON_addChangeDelete($jsonObject, 'run.use_scrolls', $run_options_cache['run.use_scrolls'])
 	_JSON_addChangeDelete($jsonObject, 'run.sort_items', $run_options_cache['run.sort_items'])
 	_JSON_addChangeDelete($jsonObject, 'run.collect_data', $run_options_cache['run.collect_data'])
+	_JSON_addChangeDelete($jsonObject, 'run.go_offline', $run_options_cache['run.go_offline'])
 	_JSON_addChangeDelete($jsonObject, 'run.donate_faction_points', $run_options_cache['run.donate_faction_points'])
 	_JSON_addChangeDelete($jsonObject, 'run.buy_faction_resources', $run_options_cache['run.buy_faction_resources'])
 	_JSON_addChangeDelete($jsonObject, 'run.buy_faction_scrolls', $run_options_cache['run.buy_faction_scrolls'])

--- a/conf/farm/Default Farm Configuration.json
+++ b/conf/farm/Default Farm Configuration.json
@@ -19,7 +19,9 @@
 		"weapon_slot": 0,
 		"bags_count": 5,
 		"district": "Random EU",
-		"disable_rendering": false
+		"disable_rendering": false,
+		"go_offline": false,
+		"flash_whisper": false
 	},
 	"team": {
 		"automatic_team_setup": false,

--- a/lib/BotsHub-GUI.au3
+++ b/lib/BotsHub-GUI.au3
@@ -102,7 +102,7 @@ Global $gui_group_teamoptions, $gui_teamlabel, $gui_teammemberlabel, $gui_teamme
 		$gui_checkbox_load_build_hero_4, $gui_checkbox_load_build_hero_5, $gui_checkbox_load_build_hero_6, $gui_checkbox_load_build_hero_7, _
 		$gui_label_build_hero_1, $gui_label_build_hero_2, $gui_label_build_hero_3, $gui_label_build_hero_4, $gui_label_build_hero_5, $gui_label_build_hero_6, $gui_label_build_hero_7, _
 		$gui_input_build_player, $gui_input_build_hero_1, $gui_input_build_hero_2, $gui_input_build_hero_3, $gui_input_build_hero_4, $gui_input_build_hero_5, $gui_input_build_hero_6, $gui_input_build_hero_7
-Global $gui_group_otheroptions, $gui_button_openstorage
+Global $gui_group_otheroptions, $gui_button_openstorage, $gui_checkbox_gooffline, $gui_checkbox_flashwhisper
 Global $gui_label_characterbuilds, $gui_label_heroesbuilds, $gui_edit_characterbuilds, $gui_edit_heroesbuilds, $gui_label_farminformations
 Global $gui_treeview_lootoptions, $gui_label_lootoptionswarning, $gui_expandlootoptionsbutton, $gui_reducelootoptionsbutton, $gui_loadlootoptionsbutton, $gui_savelootoptionsbutton, $gui_applylootoptionsbutton
 
@@ -296,18 +296,22 @@ Func CreateGUI()
 	GUICtrlSetState($gui_radiobutton_donatepoints, $GUI_CHECKED)
 	GUICtrlCreateGroup('', -99, -99, 1, 1)
 
-	$gui_group_otheroptions = GUICtrlCreateGroup('Other options', 330, 205, 295, 235)
+	$gui_group_otheroptions = GUICtrlCreateGroup('Other options', 330, 205, 295, 260)
 	$gui_checkbox_useconsumables = GUICtrlCreateCheckbox('Use optional consumables', 355, 228)
 	$gui_checkbox_useconsets = GUICtrlCreateCheckbox('Use consets', 355, 258)
 	$gui_button_openstorage = GUICtrlCreateButton('Open Storage', 351, 290, 252, 25)
 	GUICtrlSetBkColor($gui_button_openstorage, $COLOR_LIGHTBLUE)
-	$gui_renderbutton = GUICtrlCreateButton('Rendering enabled', 351, 365, 252, 25)
+	$gui_checkbox_gooffline = GUICtrlCreateCheckbox('Go offline when bot starts', 355, 325)
+	$gui_checkbox_flashwhisper = GUICtrlCreateCheckbox('Flash taskbar on whisper', 355, 355)
+	$gui_renderbutton = GUICtrlCreateButton('Rendering enabled', 351, 385, 252, 25)
 	GUICtrlSetBkColor($gui_renderbutton, $COLOR_YELLOW)
 
 	GUICtrlSetTip($gui_checkbox_farmmaterialsmidrun, 'Salvage items during runs to save space. Bot will take some salvage kits in inventory for that.')
 	GUICtrlSetTip($gui_checkbox_useconsumables, 'If bot uses consumables (cake, pie, speed boosts, etc), it will do it automatically.')
 	GUICtrlSetTip($gui_checkbox_useconsets, 'If bot can use consets, it will do it automatically.')
 	GUICtrlSetTip($gui_button_openstorage, 'Open Xunlai storage window. Works remotely - view only from explorable areas.')
+	GUICtrlSetTip($gui_checkbox_gooffline, 'Set your status to offline in the friends list when the bot starts.')
+	GUICtrlSetTip($gui_checkbox_flashwhisper, 'Flash the GW taskbar button when an incoming whisper is received while the window is not focused.')
 	GUICtrlSetTip($gui_checkbox_usescrolls, 'Automatically uses scrolls required to enter elite zones (UW, FoW, Urgoz, Deep)')
 	GUICtrlSetTip($gui_checkbox_sortitems, 'Sorts items in inventory to optimize space before loot management.')
 	GUICtrlSetTip($gui_checkbox_collectdata, 'Collects data into SQLite database. Requires SQLite to be installed and configured. Keep unticked if unsure.')
@@ -326,6 +330,8 @@ Func CreateGUI()
 	GUICtrlSetOnEvent($gui_checkbox_useconsumables, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_useconsets, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_usescrolls, 'GuiOptionsHandler')
+	GUICtrlSetOnEvent($gui_checkbox_gooffline, 'GuiOptionsHandler')
+	GUICtrlSetOnEvent($gui_checkbox_flashwhisper, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_sortitems, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_collectdata, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_radiobutton_donatepoints, 'GuiOptionsHandler')
@@ -340,8 +346,8 @@ Func CreateGUI()
 	Local $dynamicExecutionTooltip = 'Dynamic execution. It allows to run a command with' & @CRLF _
 							& 'any arguments on the fly by writing it in below field.' & @CRLF _
 							& 'Syntax: fun(arg1, arg2, arg3, [...])'
-	$gui_input_dynamicexecution = GUICtrlCreateInput('', 355, 405, 156, 20)
-	$gui_button_dynamicexecution = GUICtrlCreateButton('Run', 530, 405, 75, 20)
+	$gui_input_dynamicexecution = GUICtrlCreateInput('', 355, 425, 156, 20)
+	$gui_button_dynamicexecution = GUICtrlCreateButton('Run', 530, 425, 75, 20)
 	GUICtrlSetTip($gui_label_dynamicexecution, $dynamicExecutionTooltip)
 	GUICtrlSetTip($gui_input_dynamicexecution, $dynamicExecutionTooltip)
 	GUICtrlSetTip($gui_button_dynamicexecution, $dynamicExecutionTooltip)
@@ -635,6 +641,10 @@ Func GuiStartButtonHandler()
 		Case 'UNINITIALIZED'
 			$character_name = GUICtrlRead($gui_combo_characterchoice)
 			If (Authentification($character_name) <> $SUCCESS) Then Return
+			If $character_name <> '' Then
+				If $run_options_cache['run.go_offline'] Then SetPlayerStatus(0)
+				If $run_options_cache['run.flash_whisper'] Then EnableWhisperFlash()
+			EndIf
 			$runtime_status = 'INITIALIZED'
 			GUICtrlSetData($gui_startbutton, 'Pause')
 			GUICtrlSetBkColor($gui_startbutton, $COLOR_LIGHTCORAL)
@@ -673,6 +683,10 @@ Func GuiOptionsHandler()
 			$run_options_cache['run.use_consets'] = GUICtrlRead($gui_checkbox_useconsets) == $GUI_CHECKED
 		Case $gui_checkbox_usescrolls
 			$run_options_cache['run.use_scrolls'] = GUICtrlRead($gui_checkbox_usescrolls) == $GUI_CHECKED
+		Case $gui_checkbox_gooffline
+			$run_options_cache['run.go_offline'] = GUICtrlRead($gui_checkbox_gooffline) == $GUI_CHECKED
+		Case $gui_checkbox_flashwhisper
+			$run_options_cache['run.flash_whisper'] = GUICtrlRead($gui_checkbox_flashwhisper) == $GUI_CHECKED
 		Case $gui_checkbox_sortitems
 			$run_options_cache['run.sort_items'] = GUICtrlRead($gui_checkbox_sortitems) == $GUI_CHECKED
 		Case $gui_checkbox_collectdata
@@ -1570,6 +1584,8 @@ Func ApplyConfigToGUI()
 	GUICtrlSetState($gui_checkbox_useconsumables, $run_options_cache['run.consume_consumables'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_useconsets, $run_options_cache['run.use_consets'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_usescrolls, $run_options_cache['run.use_scrolls'] ? $GUI_CHECKED : $GUI_UNCHECKED)
+	GUICtrlSetState($gui_checkbox_gooffline, $run_options_cache['run.go_offline'] ? $GUI_CHECKED : $GUI_UNCHECKED)
+	GUICtrlSetState($gui_checkbox_flashwhisper, $run_options_cache['run.flash_whisper'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_sortitems, $run_options_cache['run.sort_items'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_collectdata, $run_options_cache['run.collect_data'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_radiobutton_donatepoints, $run_options_cache['run.donate_faction_points'] ? $GUI_CHECKED : $GUI_UNCHECKED)

--- a/lib/BotsHub-GUI.au3
+++ b/lib/BotsHub-GUI.au3
@@ -641,10 +641,6 @@ Func GuiStartButtonHandler()
 		Case 'UNINITIALIZED'
 			$character_name = GUICtrlRead($gui_combo_characterchoice)
 			If (Authentification($character_name) <> $SUCCESS) Then Return
-			If $character_name <> '' Then
-				If $run_options_cache['run.go_offline'] Then SetPlayerStatus(0)
-				If $run_options_cache['run.flash_whisper'] Then EnableWhisperFlash()
-			EndIf
 			$runtime_status = 'INITIALIZED'
 			GUICtrlSetData($gui_startbutton, 'Pause')
 			GUICtrlSetBkColor($gui_startbutton, $COLOR_LIGHTCORAL)

--- a/lib/GWA2.au3
+++ b/lib/GWA2.au3
@@ -2759,7 +2759,7 @@ EndFunc
 
 ;~ Change online status. 0 = Offline, 1 = Online, 2 = Do not disturb, 3 = Away
 Func SetPlayerStatus($status)
-	If $status < 0 Or $status > 3 Or GetPlayerStatus() == $status Then
+	If $status < 0 Or $status > 3 Then
 		Warn('Provided an incorrect status - or the player is already in the provided status.')
 		Return False
 	EndIf

--- a/lib/GWA2_Assembly.au3
+++ b/lib/GWA2_Assembly.au3
@@ -277,7 +277,7 @@ Global $trade_hack_address
 Global $labels_map[]
 
 ; [labelName, bytePattern, resultOffset, patternType, assertSourceFile, assertMessage]
-Global $scan_patterns[59][6]
+Global $scan_patterns[60][6]
 Global $scan_patterns_count = 0
 ; [file, message]
 Global $assertions_patterns_cache[]
@@ -449,7 +449,7 @@ Func RegisterScanPatterns()
 	AddScanPattern('TradePartner',				'6A008D45F8C745F801000000',												-0xC,	'hook')
 	; EncString Decoding
 	AddScanPattern('ValidateAsyncDecodeStr',	'',																		'',		'func',	'P:\Code\Engine\Text\TextApi.cpp',			'codedString')
-	If IsDeclared('CHAT_LOG_STRUCT') Then ExtendScannerWithChatLog()
+	If IsDeclared('CHAT_LOG_STRUCT') Then ExtendAddPattern()
 EndFunc
 
 
@@ -816,6 +816,7 @@ Func MapScanResultsToLabels()
 	SetLabel('TradePartnerReturn', Ptr($tempValue + 0x5))
 	; Hook log
 	If IsDeclared('g_b_Scanner') Then Extend_Scanner()
+	If IsDeclared('CHAT_LOG_STRUCT') Then ExtendScannerWithChatLog()
 	SetLabel('QueueSize', '0x00000040')
 
 	; Logging all labels
@@ -1373,6 +1374,7 @@ Func ModifyMemory()
 	AssemblerCreateUICommands()
 	AssemblerCreatePartyCommands()
 	AssemblerCreateEncStringCommands()
+	If IsDeclared('CHAT_LOG_STRUCT') Then ExtendAssembler()
 	If IsDeclared('g_b_Assembler') Then Extend_Assembler()
 
 	Local $allocationCommand = False
@@ -1503,6 +1505,7 @@ Func AssemblerCreateData()
 	_('DecodeOutputPtr/2048')
 
 	If IsDeclared('g_b_AssemblerData') Then Extend_AssemblerData()
+	If IsDeclared('CHAT_LOG_STRUCT') Then ExtendAssemblerData()
 
 	_('QueueBase/' & 256 * GetLabel('QueueSize'))
 	_('AgentCopyBase/' & 0x1C0 * 256)

--- a/lib/GWA2_Assembly.au3
+++ b/lib/GWA2_Assembly.au3
@@ -449,7 +449,7 @@ Func RegisterScanPatterns()
 	AddScanPattern('TradePartner',				'6A008D45F8C745F801000000',												-0xC,	'hook')
 	; EncString Decoding
 	AddScanPattern('ValidateAsyncDecodeStr',	'',																		'',		'func',	'P:\Code\Engine\Text\TextApi.cpp',			'codedString')
-	If IsDeclared('CHAT_LOG_STRUCT') Then ExtendAddPattern()
+	If IsDeclared('CHAT_LOG_STRUCT') Then AddChatLogScanPattern()
 EndFunc
 
 

--- a/lib/GWA2_Assembly_Chatlog.au3
+++ b/lib/GWA2_Assembly_Chatlog.au3
@@ -5,13 +5,12 @@ Global Const $CHAT_LOG_STRUCT = 'dword;wchar[256]'
 
 Global $detours_map[]
 
-Global $chat_receive_function
 Global $chat_log_counter_address
 Global $chat_message_channel_address
 Global $chat_message_ptr_address
 Global $chat_log_last_counter = 0
 
-Func ExtendAddPattern()
+Func AddChatLogScanPattern()
 	AddScanPattern('ChatLog',		'8B4508837D0C07',	-0x20,	'hook')
 EndFunc
 
@@ -131,14 +130,14 @@ Func MemoryRevertDetour($fromLabel)
 EndFunc
 
 ;------------------------------------------------------
-; Title...........:	_ChatLogOnExit
+; Title...........:	ChatLogOnExit
 ; Description.....:	OnAutoItExitRegister handler. Reverts the ChatLog detour whenever
 ;					BotsHub exits (normal close, error, or tray exit) so GW's code at
 ;					ChatLogStart is restored to its original bytes. Without this, a
 ;					subsequent BotsHub session would find a stale JMP at ChatLogStart and
 ;					crash GW the next time a chat message arrives.
 ;------------------------------------------------------
-Func _ChatLogOnExit()
+Func ChatLogOnExit()
 	AdlibUnRegister('ChatLogPollCallback')
 	MemoryRevertDetour('ChatLogStart')
 EndFunc
@@ -147,20 +146,23 @@ Func ChatLogSetEventCallback($chatReceive = '')
 	If $chatReceive <> '' Then
 		MemoryWriteDetourEx('ChatLogStart', 'ChatLogProc', 'ChatLogTrampoline')
 		$chat_log_last_counter = GetChatMessageCounter()
-		AdlibRegister('ChatLogPollCallback', 1000)
-		OnAutoItExitRegister('_ChatLogOnExit')
+		; NOTE: Polling interval cannot exceed ~100ms. GW's internal message buffer is small;
+		; slower polling causes the pointer at $msgPtr to become stale/invalid before it's read,
+		; resulting in silent failure (whisper notifications never fire).
+		; Further testing and debugging will be required to implement a more conservative frequency.
+		AdlibRegister('ChatLogPollCallback', 100)
+		OnAutoItExitRegister('ChatLogOnExit')
 	Else
 		MemoryRevertDetour('ChatLogStart')
 		AdlibUnRegister('ChatLogPollCallback')
-		OnAutoItExitUnRegister('_ChatLogOnExit')
+		OnAutoItExitUnRegister('ChatLogOnExit')
 	EndIf
 
-	$chat_receive_function = $chatReceive
 EndFunc
 
 ;------------------------------------------------------
 ; Title...........:	ChatLogPollCallback
-; Description.....:	AdlibRegister callback that fires every 1000ms (1s). Detects new chat
+; Description.....:	AdlibRegister callback that fires every 100ms. Detects new chat
 ;					messages by comparing ChatMessageCounter against the last seen value,
 ;					then reads the message from GW memory and dispatches to
 ;					$chat_receive_function. Replaces the PostMessage/GUIRegisterMsg approach
@@ -171,6 +173,14 @@ EndFunc
 ;					than plain Unicode. They are filtered out here by checking for the whisper
 ;					separator character 'Ĉ' (U+0108) which is always present in real whisper
 ;					messages and never in encoded GW strings.
+;
+;					LIMITATION: Currently only extracts sender name for 'Received Whisper'
+;					channel. Other channels (Alliance, Guild, Trade, All, etc.) dispatch with
+;					empty $message and $guildTag = 'No'. If callbacks need to parse message
+;					content from other channels, this function must be refactored to:
+;					- Read message pointer for all channels (not just whisper)
+;					- Call ChatLogParseAlliance/ChatLogParseGuild/etc. per channel type
+;					- Pass extracted message and sender to callback
 ;------------------------------------------------------
 Func ChatLogPollCallback()
 	Local $counter = GetChatMessageCounter()
@@ -214,7 +224,7 @@ Func ChatLogPollCallback()
 		$sender = StringMid($message, 3, $separatorPos - 3)
 	EndIf
 
-	Call($chat_receive_function, $channel, $sender, '', 'No')
+	WhisperFlashCallback($channel, $sender, '', 'No')
 EndFunc
 
 Func ChatLogParseAlliance($message, ByRef $sender, ByRef $tag, ByRef $text)

--- a/lib/GWA2_Assembly_Chatlog.au3
+++ b/lib/GWA2_Assembly_Chatlog.au3
@@ -8,6 +8,7 @@ Global $detours_map[]
 Global $chat_log_counter_address
 Global $chat_message_channel_address
 Global $chat_message_ptr_address
+Global $chat_message_data_address
 Global $chat_log_last_counter = 0
 
 Func AddChatLogScanPattern()
@@ -24,6 +25,7 @@ Func ExtendInitializeChatLogResult()
 	$chat_log_counter_address = GetLabel('ChatMessageCounter')
 	$chat_message_channel_address = GetLabel('ChatMessageChannel')
 	$chat_message_ptr_address = GetLabel('ChatMessagePtr')
+	$chat_message_data_address = GetLabel('ChatMessageData')
 EndFunc
 
 Func ExtendAssembler()
@@ -38,6 +40,7 @@ Func AssemblerCreateEventData()
 	_('ChatMessageCounter/4')
 	_('ChatMessageChannel/4')
 	_('ChatMessagePtr/4')
+	_('ChatMessageData/512')
 EndFunc
 
 Func AssemblerCreateChatLog()
@@ -55,6 +58,13 @@ Func AssemblerCreateChatLog()
 	_('mov dword[ChatMessageChannel],edx')
 	_('mov edx,dword[ebp+8]')
 	_('mov dword[ChatMessagePtr],edx')
+	; Copy message bytes into our owned buffer before incrementing the counter.
+	; This ensures the data is in BotsHub-controlled memory by the time the AutoIt
+	; poller detects the counter change — GW's source buffer may be freed within ~150ms.
+	_('mov esi,dword[ebp+8]')
+	_('mov edi,ChatMessageData')
+	_('mov ecx,128 -> B980000000')
+	_('rep movsd -> F3A5')
 	_('mov edx,dword[ChatMessageCounter]')
 	_('inc edx')
 	_('mov dword[ChatMessageCounter],edx')
@@ -146,11 +156,7 @@ Func ChatLogSetEventCallback($chatReceive = '')
 	If $chatReceive <> '' Then
 		MemoryWriteDetourEx('ChatLogStart', 'ChatLogProc', 'ChatLogTrampoline')
 		$chat_log_last_counter = GetChatMessageCounter()
-		; NOTE: Polling interval cannot exceed ~100ms. GW's internal message buffer is small;
-		; slower polling causes the pointer at $msgPtr to become stale/invalid before it's read,
-		; resulting in silent failure (whisper notifications never fire).
-		; Further testing and debugging will be required to implement a more conservative frequency.
-		AdlibRegister('ChatLogPollCallback', 100)
+		AdlibRegister('ChatLogPollCallback', 5000)
 		OnAutoItExitRegister('ChatLogOnExit')
 	Else
 		MemoryRevertDetour('ChatLogStart')
@@ -162,11 +168,13 @@ EndFunc
 
 ;------------------------------------------------------
 ; Title...........:	ChatLogPollCallback
-; Description.....:	AdlibRegister callback that fires every 100ms. Detects new chat
+; Description.....:	AdlibRegister callback that fires every 5000ms (5s). Detects new chat
 ;					messages by comparing ChatMessageCounter against the last seen value,
-;					then reads the message from GW memory and dispatches to
-;					$chat_receive_function. Replaces the PostMessage/GUIRegisterMsg approach
-;					to avoid cross-thread Windows API calls from inside the GW hook.
+;					then reads the message from the ChatMessageData buffer (copied directly
+;					into BotsHub-owned memory by the hook assembly) and dispatches to
+;					$chat_receive_function. This avoids reading GW's internal message pointer
+;					which is freed within ~150ms of AddToChatLog firing, making the polling
+;					frequency unconstrained.
 ;
 ;					Zone transition area-name announcements also fire AddToChatLog on channel
 ;					14 (the same slot as Received Whisper) using GW-encoded text tokens rather
@@ -212,13 +220,10 @@ Func ChatLogPollCallback()
 
 	Local $sender = ''
 	If $channel = 'Received Whisper' Then
-		; Read the GW message string from the pointer stored by the hook.
-		; Zone transition messages also arrive on channel 14 as GW-encoded text tokens
-		; (e.g. 8102 0000) and will not contain the whisper separator 'Ĉ'. If the
-		; separator is absent the event is not a real player whisper — skip it.
-		Local $msgPtr = GetChatMessagePtr()
-		If $msgPtr = 0 Then Return
-		Local $message = MemoryRead(GetProcessHandle(), $msgPtr, 'wchar[64]')
+		; Read from our owned ChatMessageData buffer — copied by the hook the instant
+		; AddToChatLog fires, so this is never stale regardless of polling frequency.
+		; Zone transition messages lack the whisper separator 'Ĉ' and are filtered here.
+		Local $message = MemoryRead(GetProcessHandle(), $chat_message_data_address, 'wchar[256]')
 		Local $separatorPos = StringInStr($message, 'Ĉ')
 		If $separatorPos = 0 Then Return
 		$sender = StringMid($message, 3, $separatorPos - 3)

--- a/lib/GWA2_Assembly_Chatlog.au3
+++ b/lib/GWA2_Assembly_Chatlog.au3
@@ -9,7 +9,10 @@ Global $chat_log_counter_address
 Global $chat_message_channel_address
 Global $chat_message_ptr_address
 Global $chat_message_data_address
+Global $whisper_counter_address
+Global $whisper_data_address
 Global $chat_log_last_counter = 0
+Global $chat_log_last_whisper_counter = 0
 
 Func AddChatLogScanPattern()
 	AddScanPattern('ChatLog',		'8B4508837D0C07',	-0x20,	'hook')
@@ -26,6 +29,8 @@ Func ExtendInitializeChatLogResult()
 	$chat_message_channel_address = GetLabel('ChatMessageChannel')
 	$chat_message_ptr_address = GetLabel('ChatMessagePtr')
 	$chat_message_data_address = GetLabel('ChatMessageData')
+	$whisper_counter_address = GetLabel('WhisperCounter')
+	$whisper_data_address = GetLabel('WhisperData')
 EndFunc
 
 Func ExtendAssembler()
@@ -41,6 +46,8 @@ Func AssemblerCreateEventData()
 	_('ChatMessageChannel/4')
 	_('ChatMessagePtr/4')
 	_('ChatMessageData/512')
+	_('WhisperCounter/4')
+	_('WhisperData/512')
 EndFunc
 
 Func AssemblerCreateChatLog()
@@ -68,6 +75,19 @@ Func AssemblerCreateChatLog()
 	_('mov edx,dword[ChatMessageCounter]')
 	_('inc edx')
 	_('mov dword[ChatMessageCounter],edx')
+	; If channel == 14 (Received Whisper, decimal 0x0E), snapshot the copied data into
+	; WhisperData and bump WhisperCounter. This isolates whisper state from subsequent
+	; messages on other channels that would otherwise overwrite ChatMessageData.
+	_('cmp dword[ebp+C],0E -> 837D0C0E')
+	_('jnz skipWhisper')
+	_('mov esi,ChatMessageData')
+	_('mov edi,WhisperData')
+	_('mov ecx,128 -> B980000000')
+	_('rep movsd -> F3A5')
+	_('mov edx,dword[WhisperCounter]')
+	_('inc edx')
+	_('mov dword[WhisperCounter],edx')
+	_('skipWhisper:')
 
 	_('popad')
 	_('popfd')
@@ -155,7 +175,7 @@ EndFunc
 Func ChatLogSetEventCallback($chatReceive = '')
 	If $chatReceive <> '' Then
 		MemoryWriteDetourEx('ChatLogStart', 'ChatLogProc', 'ChatLogTrampoline')
-		$chat_log_last_counter = GetChatMessageCounter()
+		$chat_log_last_whisper_counter = GetWhisperCounter()
 		AdlibRegister('ChatLogPollCallback', 5000)
 		OnAutoItExitRegister('ChatLogOnExit')
 	Else
@@ -168,68 +188,40 @@ EndFunc
 
 ;------------------------------------------------------
 ; Title...........:	ChatLogPollCallback
-; Description.....:	AdlibRegister callback that fires every 5000ms (5s). Detects new chat
-;					messages by comparing ChatMessageCounter against the last seen value,
-;					then reads the message from the ChatMessageData buffer (copied directly
-;					into BotsHub-owned memory by the hook assembly) and dispatches to
-;					$chat_receive_function. This avoids reading GW's internal message pointer
-;					which is freed within ~150ms of AddToChatLog firing, making the polling
-;					frequency unconstrained.
+; Description.....:	AdlibRegister callback that fires every 5000ms (5s). Detects incoming
+;					whispers by comparing WhisperCounter against the last seen value.
+;					WhisperCounter and WhisperData are written by the hook assembly only when
+;					AddToChatLog fires on channel 14 (Received Whisper), so this callback
+;					never needs to inspect the channel itself.
 ;
 ;					Zone transition area-name announcements also fire AddToChatLog on channel
-;					14 (the same slot as Received Whisper) using GW-encoded text tokens rather
-;					than plain Unicode. They are filtered out here by checking for the whisper
-;					separator character 'Ĉ' (U+0108) which is always present in real whisper
-;					messages and never in encoded GW strings.
+;					14 using GW-encoded text tokens rather than plain Unicode. They are filtered
+;					out here by checking for the whisper separator character 'Ĉ' (U+0108) which
+;					is always present in real whisper messages and never in encoded GW strings.
 ;
-;					LIMITATION: Currently only extracts sender name for 'Received Whisper'
-;					channel. Other channels (Alliance, Guild, Trade, All, etc.) dispatch with
-;					empty $message and $guildTag = 'No'. If callbacks need to parse message
-;					content from other channels, this function must be refactored to:
-;					- Read message pointer for all channels (not just whisper)
-;					- Call ChatLogParseAlliance/ChatLogParseGuild/etc. per channel type
-;					- Pass extracted message and sender to callback
+;					LIMITATION: Currently only handles 'Received Whisper'. To add general-channel
+;					alerting (e.g. scan Trade/All for "WTB conset"), register a separate
+;					AdlibRegister callback that polls GetChatMessageCounter(), reads
+;					GetChannelName(GetChatMessageChannel()) to filter by channel, and reads
+;					the message from ChatMessageData via $chat_message_data_address.
+;					For collision safety between channels, mirror the WhisperCounter/WhisperData
+;					pattern: add per-channel counter+data labels in AssemblerCreateEventData and
+;					a conditional block in AssemblerCreateChatLog that snapshots on the desired
+;					channel number.
 ;------------------------------------------------------
 Func ChatLogPollCallback()
-	Local $counter = GetChatMessageCounter()
-	If $counter = $chat_log_last_counter Then Return
-	$chat_log_last_counter = $counter
+	Local $counter = GetWhisperCounter()
+	If $counter = $chat_log_last_whisper_counter Then Return
+	$chat_log_last_whisper_counter = $counter
 
-	Local $channelType = GetChatMessageChannel()
-	Local $channel = ''
-	Switch $channelType
-		Case 0
-			$channel = 'Alliance'
-		Case 3
-			$channel = 'All'
-		Case 9
-			$channel = 'Guild'
-		Case 10
-			$channel = 'Send Whisper'
-		Case 11
-			$channel = 'Team'
-		Case 12
-			$channel = 'Trade'
-		Case 13
-			$channel = 'Advisory'
-		Case 14
-			$channel = 'Received Whisper'
-		Case Else
-			$channel = 'Other'
-	EndSwitch
+	; Read from WhisperData — isolated to channel 14 only, copied at hook-fire time.
+	; Zone transition messages lack the whisper separator 'Ĉ' and are filtered here.
+	Local $message = MemoryRead(GetProcessHandle(), $whisper_data_address, 'wchar[256]')
+	Local $separatorPos = StringInStr($message, 'Ĉ')
+	If $separatorPos = 0 Then Return
+	Local $sender = StringMid($message, 3, $separatorPos - 3)
 
-	Local $sender = ''
-	If $channel = 'Received Whisper' Then
-		; Read from our owned ChatMessageData buffer — copied by the hook the instant
-		; AddToChatLog fires, so this is never stale regardless of polling frequency.
-		; Zone transition messages lack the whisper separator 'Ĉ' and are filtered here.
-		Local $message = MemoryRead(GetProcessHandle(), $chat_message_data_address, 'wchar[256]')
-		Local $separatorPos = StringInStr($message, 'Ĉ')
-		If $separatorPos = 0 Then Return
-		$sender = StringMid($message, 3, $separatorPos - 3)
-	EndIf
-
-	WhisperFlashCallback($channel, $sender, '', 'No')
+	WhisperFlashCallback('Received Whisper', $sender, '', 'No')
 EndFunc
 
 Func ChatLogParseAlliance($message, ByRef $sender, ByRef $tag, ByRef $text)
@@ -274,6 +266,36 @@ EndFunc
 
 Func GetChatMessageCounter()
 	Return MemoryRead(GetProcessHandle(), $chat_log_counter_address)
+EndFunc
+
+Func GetWhisperCounter()
+	Return MemoryRead(GetProcessHandle(), $whisper_counter_address)
+EndFunc
+
+; Maps a raw GW channel type integer to a human-readable name.
+; Use with GetChatMessageCounter() + ChatMessageData to build general-channel alerting
+; (e.g. scan Trade or All for keyword matches).
+Func GetChannelName($channelType)
+	Switch $channelType
+		Case 0
+			Return 'Alliance'
+		Case 3
+			Return 'All'
+		Case 9
+			Return 'Guild'
+		Case 10
+			Return 'Send Whisper'
+		Case 11
+			Return 'Team'
+		Case 12
+			Return 'Trade'
+		Case 13
+			Return 'Advisory'
+		Case 14
+			Return 'Received Whisper'
+		Case Else
+			Return 'Other'
+	EndSwitch
 EndFunc
 
 Func GetChatMessageChannel()

--- a/lib/GWA2_Assembly_Chatlog.au3
+++ b/lib/GWA2_Assembly_Chatlog.au3
@@ -1,44 +1,30 @@
 #include-once
 
+; Sentinel used by GWA2_Assembly.au3 to detect this module and call the Extend* hooks.
 Global Const $CHAT_LOG_STRUCT = 'dword;wchar[256]'
 
 Global $detours_map[]
 
 Global $chat_receive_function
-Global $chat_log_base_address
 Global $chat_log_counter_address
 Global $chat_message_channel_address
+Global $chat_message_ptr_address
+Global $chat_log_last_counter = 0
 
 Func ExtendAddPattern()
-	AddScanPattern('PostMessage',	'6AFF6A00680180',	0x19,	'ptr')
 	AddScanPattern('ChatLog',		'8B4508837D0C07',	-0x20,	'hook')
 EndFunc
 
 Func ExtendScannerWithChatLog()
-	Local $postMessage = $scan_results['PostMessage']
-	SetLabel('PostMessage', Ptr(MemoryRead(GetProcessID(), $postMessage, 'dword')))
-
 	Local $tempValue = $scan_results['ChatLog']
 	SetLabel('ChatLogStart', Ptr($tempValue))
 	SetLabel('ChatLogReturn', Ptr($tempValue + 0x5))
-
-	Debug('PostMessage: ' & GetLabel('PostMessage'))
-	Debug('ChatLogStart: ' & GetLabel('ChatLogStart'))
-	Debug('ChatLogReturn: ' & GetLabel('ChatLogReturn'))
-
-	SetLabel('ChatLogCallbackEvent', '0x00000501')
-	SetLabel('ChatLogSize', '0x00000010')
 EndFunc
 
 Func ExtendInitializeChatLogResult()
-	Local $chatLogGUI = GUICreate('ChatLogGUI')
-	GUIRegisterMsg(0x00000501, 'ChatLogEventCallback')
-	MemoryWrite(GetProcessHandle(), GetLabel('ChatLogCallbackHandle'), $chatLogGUI)
-	Debug('ChatLogCallbackHandle: ' & GetLabel('ChatLogCallbackHandle'))
-
-	$chat_log_base_address = GetLabel('ChatLogBase')
 	$chat_log_counter_address = GetLabel('ChatMessageCounter')
 	$chat_message_channel_address = GetLabel('ChatMessageChannel')
+	$chat_message_ptr_address = GetLabel('ChatMessagePtr')
 EndFunc
 
 Func ExtendAssembler()
@@ -50,65 +36,44 @@ Func ExtendAssemblerData()
 EndFunc
 
 Func AssemblerCreateEventData()
-	_('ChatLogCallbackHandle/4')
-	_('ChatLogCallbackEvent/4')
-
-	_('ChatLogLastMsg/4')
-	_('ChatLogCounter/4')
 	_('ChatMessageCounter/4')
 	_('ChatMessageChannel/4')
-
-	_('ChatLogBase/' & 512)
+	_('ChatMessagePtr/4')
 EndFunc
 
 Func AssemblerCreateChatLog()
+	; ChatLogProc label BEFORE nop x4: GetLabel('ChatLogProc') = physical_nop_start+4 = pushfd address.
+	; The entry JMP targets GetLabel('ChatLogProc') and lands correctly at pushfd.
 	_('ChatLogProc:')
+	_('nop x4')
 	_('pushfd')
 	_('pushad')
-	_('mov ecx,dword[esp+30]')
-	_('add ecx,4')
-	_('xor ebx,ebx')
-	_('mov eax,ChatLogBase')
-
-	_('ChatLogCopyLoop:')
-	_('mov dx,word[ecx]')
-	_('mov word[eax],dx')
-	_('add ecx,2')
-	_('add eax,2')
-	_('inc ebx')
-	_('cmp ebx,FF')
-	_('jz ChatLogCopyExit')
-	_('test dx,dx')
-	_('jnz ChatLogCopyLoop')
-
-	_('ChatLogCopyExit:')
-	_('mov edx,dword[esp+34]')
+	; AddToChatLog uses EBP-relative argument access (inherited from caller frame).
+	; Original first instruction: MOV EAX,[EBP+8] confirms EBP is valid at hook point.
+	;   [ebp+8] = message ptr (wchar_t*)
+	;   [ebp+C] = channel (uint32_t)
+	_('mov edx,dword[ebp+C]')
 	_('mov dword[ChatMessageChannel],edx')
-	_('push eax')
-	_('mov eax,ChatLogBase')
-	_('sub eax,4')
-	_('mov dword[eax],edx')
-	_('pop eax')
+	_('mov edx,dword[ebp+8]')
+	_('mov dword[ChatMessagePtr],edx')
 	_('mov edx,dword[ChatMessageCounter]')
 	_('inc edx')
 	_('mov dword[ChatMessageCounter],edx')
-	_('push 1')
-	_('mov edx,ChatLogBase')
-	_('sub edx,4')
-	_('push edx')
-	_('push ChatLogCallbackEvent')
-	_('push dword[ChatLogCallbackHandle]')
-	_('call dword[PostMessage]')
 
 	_('popad')
 	_('popfd')
+	_('ljmp ChatLogTrampoline')
 
-	_('mov eax,dword[ebp+8]')
-	_('test eax,eax')
+	; ChatLogTrampoline label BEFORE nop x4: GetLabel('ChatLogTrampoline') = nop_start+4 = nop_x5 address.
+	; WriteBinary writes the 5 original function bytes at exactly nop_x5, not 4 bytes into it.
+	; ljmp ChatLogReturn is at nop_x5+5, safe from overflow.
+	_('ChatLogTrampoline:')
+	_('nop x4')
+	_('nop x5')
 	_('ljmp ChatLogReturn')
 EndFunc
 
-Func MemoryWriteDetourEx($fromLabel, $toLabel)
+Func MemoryWriteDetourEx($fromLabel, $toLabel, $trampolineLabel)
 	Local $labelPtr = GetLabel($fromLabel)
 	Local $buffer = DllStructCreate('byte[5]')
 
@@ -119,13 +84,38 @@ Func MemoryWriteDetourEx($fromLabel, $toLabel)
 		'ulong_ptr', 5, _
 		'ulong_ptr*', 0)
 
+	; Detect stale hook: if the first byte is E9 (JMP), a previous BotsHub session installed
+	; this hook and did not revert it before closing. The trampoline slot already holds the
+	; correct original GW bytes from that session. Read from there instead of using the stale
+	; JMP bytes at fromLabel, which would produce a garbage trampoline and crash GW.
+	Local $isStale = (DllStructGetData($buffer, 1, 1) = 0xE9)
+	If $isStale Then
+		DllCall($kernel_handle, 'bool', 'ReadProcessMemory', _
+			'handle', GetProcessHandle(), _
+			'ptr', GetLabel($trampolineLabel), _
+			'ptr', DllStructGetPtr($buffer), _
+			'ulong_ptr', 5, _
+			'ulong_ptr*', 0)
+	EndIf
+
 	Local $originalOpCode = ''
 	For $i = 1 To 5
 		$originalOpCode &= Hex(DllStructGetData($buffer, 1, $i), 2)
 	Next
 	$detours_map[$fromLabel] = $originalOpCode
 
-	WriteBinary(GetProcessHandle(), 'E9' & SwapEndian(Hex(GetLabel($toLabel) - GetLabel($fromLabel) - 5)), GetLabel($fromLabel))
+	If Not $isStale Then
+		; Write original bytes into trampoline, replacing CC (INT 3 hotpatch byte) with 90 (NOP)
+		; to prevent GW from closing when the trampoline executes with no debugger attached
+		Local $trampolineBytes = $originalOpCode
+		If StringLeft($trampolineBytes, 2) = 'CC' Then
+			$trampolineBytes = '90' & StringMid($trampolineBytes, 3)
+		EndIf
+		WriteBinary(GetProcessHandle(), $trampolineBytes, GetLabel($trampolineLabel))
+	EndIf
+
+	Local $jmpOffset = GetLabel($toLabel) - GetLabel($fromLabel) - 5
+	WriteBinary(GetProcessHandle(), 'E9' & SwapEndian(Hex($jmpOffset, 8)), GetLabel($fromLabel))
 EndFunc
 
 Func MemoryRevertDetour($fromLabel)
@@ -140,69 +130,95 @@ Func MemoryRevertDetour($fromLabel)
 	Return True
 EndFunc
 
+;------------------------------------------------------
+; Title...........:	_ChatLogOnExit
+; Description.....:	OnAutoItExitRegister handler. Reverts the ChatLog detour whenever
+;					BotsHub exits (normal close, error, or tray exit) so GW's code at
+;					ChatLogStart is restored to its original bytes. Without this, a
+;					subsequent BotsHub session would find a stale JMP at ChatLogStart and
+;					crash GW the next time a chat message arrives.
+;------------------------------------------------------
+Func _ChatLogOnExit()
+	AdlibUnRegister('ChatLogPollCallback')
+	MemoryRevertDetour('ChatLogStart')
+EndFunc
+
 Func ChatLogSetEventCallback($chatReceive = '')
 	If $chatReceive <> '' Then
-		MemoryWriteDetourEx('ChatLogStart', 'ChatLogProc')
+		MemoryWriteDetourEx('ChatLogStart', 'ChatLogProc', 'ChatLogTrampoline')
+		$chat_log_last_counter = GetChatMessageCounter()
+		AdlibRegister('ChatLogPollCallback', 1000)
+		OnAutoItExitRegister('_ChatLogOnExit')
 	Else
 		MemoryRevertDetour('ChatLogStart')
+		AdlibUnRegister('ChatLogPollCallback')
+		OnAutoItExitUnRegister('_ChatLogOnExit')
 	EndIf
 
 	$chat_receive_function = $chatReceive
-
-	Info('ChatLog event callbacks configured')
 EndFunc
 
-Func ChatLogEventCallback($handle, $uselessMessage, $param1, $param2)
-	Switch $param2
-		Case 0x1
-			Local $chatLogStruct = DllStructCreate($CHAT_LOG_STRUCT)
-			DllCall($kernel_handle, 'int', 'ReadProcessMemory', 'int', GetProcessHandle(), 'int', $param1, 'ptr', DllStructGetPtr($chatLogStruct), 'int', 512, 'int', '')
-			Local $channelType = DllStructGetData($chatLogStruct, 1)
-			Local $message = DllStructGetData($chatLogStruct, 2)
-			Local $channel = ''
-			Local $sender = ''
-			Local $guildTag = 'No'
+;------------------------------------------------------
+; Title...........:	ChatLogPollCallback
+; Description.....:	AdlibRegister callback that fires every 100ms. Detects new chat messages
+;					by comparing ChatMessageCounter against the last seen value, then reads
+;					the message from GW memory and dispatches to $chat_receive_function.
+;					Replaces the PostMessage/GUIRegisterMsg approach to avoid cross-thread
+;					Windows API calls from inside the GW hook.
+;
+;					Zone transition area-name announcements also fire AddToChatLog on channel
+;					14 (the same slot as Received Whisper) using GW-encoded text tokens rather
+;					than plain Unicode. They are filtered out here by checking for the whisper
+;					separator character 'Ĉ' (U+0108) which is always present in real whisper
+;					messages and never in encoded GW strings.
+;------------------------------------------------------
+Func ChatLogPollCallback()
+	Local $counter = GetChatMessageCounter()
+	If $counter = $chat_log_last_counter Then Return
+	$chat_log_last_counter = $counter
 
-			Switch $channelType
-				Case 0
-					$channel = 'Alliance'
-					ChatLogParseAlliance($message, $sender, $guildTag, $message)
-				Case 3
-					$channel = 'All'
-					ChatLogParseGeneral($message, $sender, $message)
-				Case 9
-					$channel = 'Guild'
-					ChatLogParseGuild($message, $sender, $message)
-				Case 11
-					$channel = 'Team'
-					ChatLogParseGeneral($message, $sender, $message)
-				Case 12
-					$channel = 'Trade'
-					ChatLogParseGeneral($message, $sender, $message)
-				Case 10
-					$channel = 'Send Whisper'
-					ParseWhisper($message, $sender, $message)
-				Case 13
-					$channel = 'Advisory'
-					$sender = 'Guild Wars'
-					$message = ''
-				Case 14
-					$channel = 'Received Whisper'
-					ParseWhisper($message, $sender, $message, 1)
-				Case Else
-					$channel = 'Other'
-					$sender = 'Other'
-			EndSwitch
-
-			Call($chat_receive_function, $channel, $sender, $message, $guildTag)
-			Debug('Channel: ' & $channel & ' Sender: ' & $sender & ' Guild: ' & $guildTag & ' Message: ' & $message)
+	Local $channelType = GetChatMessageChannel()
+	Local $channel = ''
+	Switch $channelType
+		Case 0
+			$channel = 'Alliance'
+		Case 3
+			$channel = 'All'
+		Case 9
+			$channel = 'Guild'
+		Case 10
+			$channel = 'Send Whisper'
+		Case 11
+			$channel = 'Team'
+		Case 12
+			$channel = 'Trade'
+		Case 13
+			$channel = 'Advisory'
+		Case 14
+			$channel = 'Received Whisper'
+		Case Else
+			$channel = 'Other'
 	EndSwitch
 
-	Return 0
+	Local $sender = ''
+	If $channel = 'Received Whisper' Then
+		; Read the GW message string from the pointer stored by the hook.
+		; Zone transition messages also arrive on channel 14 as GW-encoded text tokens
+		; (e.g. 8102 0000) and will not contain the whisper separator 'Ĉ'. If the
+		; separator is absent the event is not a real player whisper — skip it.
+		Local $msgPtr = GetChatMessagePtr()
+		If $msgPtr = 0 Then Return
+		Local $message = MemoryRead(GetProcessHandle(), $msgPtr, 'wchar[64]')
+		Local $separatorPos = StringInStr($message, 'Ĉ')
+		If $separatorPos = 0 Then Return
+		$sender = StringMid($message, 3, $separatorPos - 3)
+	EndIf
+
+	Call($chat_receive_function, $channel, $sender, '', 'No')
 EndFunc
 
 Func ChatLogParseAlliance($message, ByRef $sender, ByRef $tag, ByRef $text)
-	Local $tagSeparator = 'Ĉ', $textSeparator = 'ċĈć'
+	Local $tagSeparator = 'Ĉ', $textSeparator = 'ċĈć'
 	Local $tagSeparatorPos = StringInStr($message, $tagSeparator)
 	Local $textSeparatorPos = StringInStr($message, $textSeparator)
 	Local $tagStart = $tagSeparatorPos + StringLen($tagSeparator)
@@ -210,41 +226,83 @@ Func ChatLogParseAlliance($message, ByRef $sender, ByRef $tag, ByRef $text)
 
 	$sender = StringMid($message, 3, $tagSeparatorPos - 3)
 	$tag = StringMid($message, $tagStart, $textSeparatorPos - $tagStart)
-	$text = StringMid($message, $textStart, StringInStr($message, '', 0, 1, $textStart) - $textStart)
+	$text = StringMid($message, $textStart, StringInStr($message, '', 0, 1, $textStart) - $textStart)
 EndFunc
 
-Func ChatLogParseGuild($message, ByRef $sender, ByRef $text, $separator = 'ċĈć')
+Func ChatLogParseGuild($message, ByRef $sender, ByRef $text, $separator = 'ċĈć')
 	Local $separatorPos = StringInStr($message, $separator)
 	Local $textStart = $separatorPos + StringLen($separator)
 
 	$sender = StringLeft($message, $separatorPos - 1)
-	$text = StringMid($message, $textStart, StringInStr($message, '', 0, 1, $textStart) - $textStart)
+	$text = StringMid($message, $textStart, StringInStr($message, '', 0, 1, $textStart) - $textStart)
 EndFunc
 
-Func ChatLogParseGeneral($message, ByRef $sender, ByRef $text, $separator = 'ċĈć')
+Func ChatLogParseGeneral($message, ByRef $sender, ByRef $text, $separator = 'ċĈć')
 	Local $separatorPos = StringInStr($message, $separator)
 	If $separatorPos = 0 Then
-		$separator = 'ċ脂໾ć'
+		$separator = 'ċ脂໾ć'
 		$separatorPos = StringInStr($message, $separator)
 	EndIf
 	Local $textStart = $separatorPos + StringLen($separator)
 
 	$sender = StringMid($message, 3, $separatorPos - 3)
-	$text = StringMid($message, $textStart, StringInStr($message, '', 0, 1, $textStart) - $textStart)
+	$text = StringMid($message, $textStart, StringInStr($message, '', 0, 1, $textStart) - $textStart)
 EndFunc
 
 Func ParseWhisper($message, ByRef $sender, ByRef $text, $sendreceive = 0)
-	Local $separatorPos = StringInStr($message, 'Ĉ')
+	Local $separatorPos = StringInStr($message, 'Ĉ')
 	Local $textStart = $separatorPos + 2
 
 	$sender = ($sendreceive = 0 ? StringMid($message, 3, $separatorPos - 3) : StringLeft($message, $separatorPos - 1))
-	$text = StringMid($message, $textStart, StringInStr($message, '', 0, 1, $textStart) - $textStart)
+	$text = StringMid($message, $textStart, StringInStr($message, '', 0, 1, $textStart) - $textStart)
 EndFunc
 
 Func GetChatMessageCounter()
-	Return MemoryRead(GetProcessID(), $chat_log_counter_address)
+	Return MemoryRead(GetProcessHandle(), $chat_log_counter_address)
 EndFunc
 
 Func GetChatMessageChannel()
-	Return MemoryRead(GetProcessID(), $chat_message_channel_address)
+	Return MemoryRead(GetProcessHandle(), $chat_message_channel_address)
+EndFunc
+
+Func GetChatMessagePtr()
+	Return MemoryRead(GetProcessHandle(), $chat_message_ptr_address)
+EndFunc
+
+;------------------------------------------------------
+; Title...........:	FlashGWWindow
+; Description.....:	Flash the GW taskbar button until the user focuses the window.
+;					Uses FlashWindowEx with FLASHW_TRAY | FLASHW_TIMERNOFG (0xE).
+;------------------------------------------------------
+Func FlashGWWindow()
+	Local Const $FLASHW_TRAY = 0x2
+	Local Const $FLASHW_TIMERNOFG = 0xC
+	Local $flashwInfo = DllStructCreate('uint;hwnd;dword;uint;dword')
+	DllStructSetData($flashwInfo, 1, DllStructGetSize($flashwInfo))
+	DllStructSetData($flashwInfo, 2, GetWindowHandle())
+	DllStructSetData($flashwInfo, 3, BitOR($FLASHW_TRAY, $FLASHW_TIMERNOFG))
+	DllStructSetData($flashwInfo, 4, 0)
+	DllStructSetData($flashwInfo, 5, 0)
+	DllCall('user32.dll', 'bool', 'FlashWindowEx', 'ptr', DllStructGetPtr($flashwInfo))
+EndFunc
+
+;------------------------------------------------------
+; Title...........:	WhisperFlashCallback
+; Description.....:	Chat log callback that flashes the GW taskbar button when a whisper is received.
+;------------------------------------------------------
+Func WhisperFlashCallback($channel, $sender, $message, $guildTag)
+	If $channel = 'Received Whisper' Then
+		Info('[ChatLog] Whisper from ' & $sender)
+		FlashGWWindow()
+	EndIf
+EndFunc
+
+;------------------------------------------------------
+; Title...........:	EnableWhisperFlash
+; Description.....:	Installs the chat log hook and registers WhisperFlashCallback so the
+;					GW taskbar button flashes whenever an incoming whisper is intercepted.
+;					Requires GWA2 to be fully initialized before calling.
+;------------------------------------------------------
+Func EnableWhisperFlash()
+	ChatLogSetEventCallback('WhisperFlashCallback')
 EndFunc

--- a/lib/GWA2_Assembly_Chatlog.au3
+++ b/lib/GWA2_Assembly_Chatlog.au3
@@ -160,11 +160,11 @@ EndFunc
 
 ;------------------------------------------------------
 ; Title...........:	ChatLogPollCallback
-; Description.....:	AdlibRegister callback that fires every 100ms. Detects new chat messages
-;					by comparing ChatMessageCounter against the last seen value, then reads
-;					the message from GW memory and dispatches to $chat_receive_function.
-;					Replaces the PostMessage/GUIRegisterMsg approach to avoid cross-thread
-;					Windows API calls from inside the GW hook.
+; Description.....:	AdlibRegister callback that fires every 1000ms (1s). Detects new chat
+;					messages by comparing ChatMessageCounter against the last seen value,
+;					then reads the message from GW memory and dispatches to
+;					$chat_receive_function. Replaces the PostMessage/GUIRegisterMsg approach
+;					to avoid cross-thread Windows API calls from inside the GW hook.
 ;
 ;					Zone transition area-name announcements also fire AddToChatLog on channel
 ;					14 (the same slot as Received Whisper) using GW-encoded text tokens rather


### PR DESCRIPTION
- add .files and .folders/ to gitignore except .github/ and .gitignore
- Add 'go offline' option: sets player status to offline when bot starts
- Add 'flash whisper' option: flashes GW taskbar button on incoming whisper
- Add corresponding GUI checkboxes with tooltips
- Integrate options into config JSON serialization/deserialization
- Refactor ChatLog detour from PostMessage/GUIRegisterMsg to adlib polling (1s atm)
  - Fixes stale hook detection and graceful cleanup on exit
  - Filters out zone-transition GW-encoded messages from real whispers
  - Improves reliability and eliminates cross-thread API issues
- Remove undefined GetPlayerStatus() call from SetPlayerStatus validation (can add back if we figure out proper function, gwau3 is missing too)