### PR TITLE
feat: rewrite WriteChat to use kWriteToChatLog via CommandUIMsg

### DIFF
--- a/lib/GWA2.au3
+++ b/lib/GWA2.au3
@@ -2333,20 +2333,41 @@ EndFunc
 
 
 #Region Chat
-;~ Write a message in chat (can only be seen by user).
-Func WriteChat($message, $sender = 'GWA2')
+;~ Write a message in the local chat log (client-only, never sent to server).
+;~ Uses kWriteToChatLog (0x1000007F) via CommandUIMsg.
+;~ channel: 2=GWCA1, 3=All, 6=Emote, 7=Warning, 9=Guild, 11=Group
+Func WriteChat($message, $sender = '[Bhub]', $channel = 6)
 	Local $processHandle = GetProcessHandle()
 	Local $address = 256 * $queue_counter + $queue_base_address
 	$queue_counter = Mod($queue_counter + 1, $queue_size)
 
-	If StringLen($sender) > 19 Then $sender = StringLeft($sender, 19)
-	MemoryWrite($processHandle, $address + 4, $sender, 'wchar[20]')
-
 	If StringLen($message) > 100 Then $message = StringLeft($message, 100)
-	MemoryWrite($processHandle, $address + 44, $message, 'wchar[101]')
 
-	SafeDllCall13($kernel_handle, 'int', 'WriteProcessMemory', 'int', $processHandle, 'int', $address, 'ptr', $WRITE_CHAT_STRUCT_PTR, 'int', 4, 'int', 0)
-	If StringLen($message) > 100 Then WriteChat(StringTrimLeft($message, 100), $sender)
+	; GW1 encoded string: \x108\x107{text}\x1 (must use ChrW for codepoints > 255)
+	Local $ESC = ChrW(0x108) & ChrW(0x107)
+	Local $END = ChrW(0x1)
+	Local $displayStr
+	If $sender <> '' Then
+		; WriteChatEnc format: \x76b\x10a{senderEnc}\x1\x10b{msgEnc}\x1
+		Local $senderEnc = $ESC & $sender & $END
+		Local $msgEnc = $ESC & $message & $END
+		$displayStr = ChrW(0x76b) & ChrW(0x10a) & $senderEnc & $END & ChrW(0x10b) & $msgEnc & $END
+	Else
+		$displayStr = $ESC & $message & $END
+	EndIf
+
+	; Write encoded string into the queue slot after the 20-byte struct
+	Local $msgGWAddr = $address + 20
+	MemoryWrite($processHandle, $msgGWAddr, $displayStr, 'wchar[' & (StringLen($displayStr) + 1) & ']')
+
+	; CommandUIMsg struct: [fn ptr][kWriteToChatLog][channel][msg ptr][channel]
+	Local $s = DllStructCreate('dword;dword;dword;dword;dword')
+	DllStructSetData($s, 1, GetLabel('CommandUIMsg'))
+	DllStructSetData($s, 2, 0x1000007F)   ; kWriteToChatLog
+	DllStructSetData($s, 3, $channel)
+	DllStructSetData($s, 4, $msgGWAddr)   ; GW1-side pointer to encoded message
+	DllStructSetData($s, 5, $channel)
+	SafeDllCall13($kernel_handle, 'int', 'WriteProcessMemory', 'int', $processHandle, 'int', $address, 'ptr', DllStructGetPtr($s), 'int', DllStructGetSize($s), 'int', 0)
 EndFunc
 
 

--- a/lib/GWA2.au3
+++ b/lib/GWA2.au3
@@ -2342,6 +2342,12 @@ Func WriteChat($message, $sender = '[Bhub]', $channel = 6)
 	$queue_counter = Mod($queue_counter + 1, $queue_size)
 
 	If StringLen($message) > 100 Then $message = StringLeft($message, 100)
+	; Slot: 256 bytes, struct: 20 bytes → 118 wchars available (incl null).
+	; Sender-path fixed overhead: 11 chars + message, so sender max = 106 - msgLen.
+	If $sender <> '' Then
+		Local $maxSenderLen = 106 - StringLen($message)
+		If StringLen($sender) > $maxSenderLen Then $sender = StringLeft($sender, $maxSenderLen)
+	EndIf
 
 	; GW1 encoded string: \x108\x107{text}\x1 (must use ChrW for codepoints > 255)
 	Local $ESC = ChrW(0x108) & ChrW(0x107)

--- a/src/utilities/TestSuite.au3
+++ b/src/utilities/TestSuite.au3
@@ -62,6 +62,9 @@ Func RunTests()
 	;Info(DllStructGetData(GetEffect($ID_SHROUD_OF_DISTRESS), 'TimeStamp'))
 	;Info(GetEffectTimeRemaining(GetEffect($ID_SHROUD_OF_DISTRESS)))
 
+	;WriteChat('WriteChat: Test full function input.', '[Bhub]', 6)
+	;WriteChat('WriteChat: Test lazy input.')
+
 	Return $PAUSE
 EndFunc
 

--- a/src/utilities/TestSuite.au3
+++ b/src/utilities/TestSuite.au3
@@ -62,8 +62,10 @@ Func RunTests()
 	;Info(DllStructGetData(GetEffect($ID_SHROUD_OF_DISTRESS), 'TimeStamp'))
 	;Info(GetEffectTimeRemaining(GetEffect($ID_SHROUD_OF_DISTRESS)))
 
-	;WriteChat('WriteChat: Test full function input.', '[Bhub]', 6)
-	;WriteChat('WriteChat: Test lazy input.')
+	;Local $WriteChatChan = 6
+	;Local $WriteChatSender = '[Vaettir-Bot]'
+	;WriteChat('Test full function input.', $WriteChatSender, $WriteChatChan)
+	;WriteChat('Test lazy input.')
 
 	Return $PAUSE
 EndFunc


### PR DESCRIPTION
Switches from the old $WRITE_CHAT_STRUCT_PTR approach to GW1-encoded strings dispatched through CommandUIMsg, adding $channel support and proper sender/message encoding.