### PR TITLE
fix: honor alcohol storage setting

### DIFF
--- a/lib/Utils-Storage.au3
+++ b/lib/Utils-Storage.au3
@@ -533,6 +533,9 @@ Func DefaultShouldStoreItem($item)
 		;Return ContainsValuableUpgrades($item)
 		Return $cache['Store items.Armor salvageables.' & $rarityName]
 	; ------------------------------------- Consumables -------------------------------------
+	ElseIf IsAlcohol($itemID) Then
+		If $quantity <> 250 Then Return False
+		Return $cache['Store items.Alcohols']
 	ElseIf IsConsumable($itemID) Then
 		If $quantity <> 250 Then Return False
 		Return $cache['Store items.Consumables']


### PR DESCRIPTION
## Summary
- route alcohol through the dedicated `Store items.Alcohols` setting
- preserve the existing full-stack-only storage behavior
- leave other consumables controlled by `Store items.Consumables`

## Problem
`IsConsumable()` includes alcohol, so the existing storage branch always reads `Store items.Consumables` for alcohol and never reads the dedicated alcohol option.

## Validation
- `git diff --check` passes
- AutoIt control flow matches the existing alcohol-specific pickup handling
- full-project `Au3Check` remains blocked by pre-existing errors in unrelated upstream code