### PR TITLE
Add shield attribute filters to loot profiles

### DIFF
--- a/BotsHub.au3
+++ b/BotsHub.au3
@@ -388,9 +388,56 @@ Func LoadLootConfiguration($filePath)
 	$loot_configuration = StringTrimRight($loot_configuration, 5)
 	Local $jsonLootOptions = LoadLootOptions($filePath)
 	FillInventoryCacheFromJSON($jsonLootOptions, '')
+	ExpandShieldRequirementSettings()
 	BuildInventoryDerivedFlags()
 	RefreshValuableListsFromCache()
 	Info('Loaded loot configuration at ' & $filePath)
+EndFunc
+
+
+;~ Expand legacy Shield.Req N settings into attribute-specific shield settings.
+;~ The loot tree is generated from this cache, so existing profiles gain the new
+;~ hierarchy without requiring a destructive file migration.
+Func ExpandShieldRequirementSettings()
+	Local Static $configurationRoots[] = ['Pick up items', 'Salvage items', 'Sell items', 'Store items']
+	Local Static $rarities[] = ['White', 'Blue', 'Purple', 'Gold', 'Green']
+	Local Static $shieldAttributes[] = ['Strength', 'Tactics', 'Leadership', 'Command', 'Motivation', 'Other']
+
+	For $configurationRoot In $configurationRoots
+		For $rarity In $rarities
+			Local $shieldPath = $configurationRoot & '.Weapons and offhands.' & $rarity & '.Shield'
+			Local $hasLegacySettings = False
+
+			For $requirement = 0 To 13
+				If MapExists($inventory_management_cache, $shieldPath & '.Req ' & $requirement) Then $hasLegacySettings = True
+			Next
+
+			If Not $hasLegacySettings Then ContinueLoop
+			Local $shieldValue = True
+			For $attributeIndex = 0 To UBound($shieldAttributes) - 1
+				Local $attributePath = $shieldPath & '.' & $shieldAttributes[$attributeIndex]
+				Local $attributeValue = True
+
+				For $requirement = 0 To 13
+					Local $legacyPath = $shieldPath & '.Req ' & $requirement
+					Local $attributeRequirementPath = $attributePath & '.Req ' & $requirement
+					If Not MapExists($inventory_management_cache, $attributeRequirementPath) Then
+						$inventory_management_cache[$attributeRequirementPath] = MapExists($inventory_management_cache, $legacyPath) ? $inventory_management_cache[$legacyPath] : False
+					EndIf
+					If Not $inventory_management_cache[$attributeRequirementPath] Then $attributeValue = False
+				Next
+
+				$inventory_management_cache[$attributePath] = $attributeValue
+				If Not $attributeValue Then $shieldValue = False
+			Next
+
+			For $requirement = 0 To 13
+				Local $legacyCleanupPath = $shieldPath & '.Req ' & $requirement
+				If MapExists($inventory_management_cache, $legacyCleanupPath) Then MapRemove($inventory_management_cache, $legacyCleanupPath)
+			Next
+			$inventory_management_cache[$shieldPath] = $shieldValue
+		Next
+	Next
 EndFunc
 
 

--- a/lib/Utils-Storage.au3
+++ b/lib/Utils-Storage.au3
@@ -664,45 +664,66 @@ Func CheckPickupWeapon($weaponItem)
 	If $weaponRarity <> $RARITY_WHITE And IsLowReqMaxStats($weaponItem) Then Return True
 	Local $itemID = DllStructGetData($weaponItem, 'ModelID')
 	If $weaponRarity <> $RARITY_WHITE And $RARE_WEAPONS_TO_PICK[$itemID] <> Null And IsMaxStatsForReq($weaponItem) Then Return True
-
-	Local $weaponRarityName = $RARITY_NAMES_FROM_IDS[$weaponRarity]
-	Local $weaponType = DllStructGetData($weaponItem, 'Type')
-	Local $weaponTypeName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
-	Local $weaponReq = GetItemReq($weaponItem)
-	Return $inventory_management_cache['Pick up items.Weapons and offhands.' & $weaponRarityName & '.' & $weaponTypeName & '.Req ' & $weaponReq]
+	Return CheckConfiguredWeaponAction('Pick up items', $weaponItem)
 EndFunc
 
 
 Func CheckSalvageWeapon($weaponItem)
 	Local $weaponRarity = GetRarity($weaponItem)
 	If $weaponRarity == $RARITY_GREEN Or $weaponRarity == $RARITY_GRAY Or $weaponRarity == $RARITY_RED Then Return False
-	Local $weaponRarityName = $RARITY_NAMES_FROM_IDS[$weaponRarity]
-	Local $weaponType = DllStructGetData($weaponItem, 'Type')
-	Local $weaponTypeName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
-	Local $weaponReq = GetItemReq($weaponItem)
-	Return $inventory_management_cache['Salvage items.Weapons and offhands.' & $weaponRarityName & '.' & $weaponTypeName & '.Req ' & $weaponReq]
+	Return CheckConfiguredWeaponAction('Salvage items', $weaponItem)
 EndFunc
 
 
 Func CheckSellWeapon($weaponItem)
 	Local $weaponRarity = GetRarity($weaponItem)
 	If $weaponRarity == $RARITY_GREEN Or $weaponRarity == $RARITY_GRAY Or $weaponRarity == $RARITY_RED Then Return False
-	Local $weaponRarityName = $RARITY_NAMES_FROM_IDS[$weaponRarity]
-	Local $weaponType = DllStructGetData($weaponItem, 'Type')
-	Local $weaponTypeName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
-	Local $weaponReq = GetItemReq($weaponItem)
-	Return $inventory_management_cache['Sell items.Weapons and offhands.' & $weaponRarityName & '.' & $weaponTypeName & '.Req ' & $weaponReq]
+	Return CheckConfiguredWeaponAction('Sell items', $weaponItem)
 EndFunc
 
 
 Func CheckStoreWeapon($weaponItem)
 	Local $weaponRarity = GetRarity($weaponItem)
 	If $weaponRarity == $RARITY_GRAY Or $weaponRarity == $RARITY_RED Then Return False
+	Return CheckConfiguredWeaponAction('Store items', $weaponItem)
+EndFunc
+
+
+;~ Return the configured action for a weapon. Shields include their required
+;~ attribute in the configuration path; other weapon paths remain unchanged.
+Func CheckConfiguredWeaponAction($configurationRoot, $weaponItem)
+	Local $weaponRarity = GetRarity($weaponItem)
 	Local $weaponRarityName = $RARITY_NAMES_FROM_IDS[$weaponRarity]
 	Local $weaponType = DllStructGetData($weaponItem, 'Type')
 	Local $weaponTypeName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
 	Local $weaponReq = GetItemReq($weaponItem)
-	Return $inventory_management_cache['Store items.Weapons and offhands.' & $weaponRarityName & '.' & $weaponTypeName & '.Req ' & $weaponReq]
+	Local $configurationPath = $configurationRoot & '.Weapons and offhands.' & $weaponRarityName & '.' & $weaponTypeName
+
+	If $weaponType == $ID_TYPE_SHIELD Then
+		Local $attributePath = $configurationPath & '.' & GetShieldAttributeConfigurationName($weaponItem) & '.Req ' & $weaponReq
+		If MapExists($inventory_management_cache, $attributePath) Then Return $inventory_management_cache[$attributePath]
+	EndIf
+
+	Return $inventory_management_cache[$configurationPath & '.Req ' & $weaponReq]
+EndFunc
+
+
+;~ Return the shield attribute category used by loot configurations.
+Func GetShieldAttributeConfigurationName($shieldItem)
+	Switch GetItemAttribute($shieldItem)
+		Case $ID_STRENGTH
+			Return 'Strength'
+		Case $ID_TACTICS
+			Return 'Tactics'
+		Case $ID_LEADERSHIP
+			Return 'Leadership'
+		Case $ID_COMMAND
+			Return 'Command'
+		Case $ID_MOTIVATION
+			Return 'Motivation'
+		Case Else
+			Return 'Other'
+	EndSwitch
 EndFunc
 #EndRegion Inventory Management
 


### PR DESCRIPTION
## Summary

This adds attribute filtering for shields in loot profiles.

Shield settings are now grouped as:

- Strength
- Tactics
- Leadership
- Command
- Motivation
- Other

Each group keeps the existing Req 0 through Req 13 choices. The same lookup is used for pickup, salvage, sell, and store decisions. Non-shield weapon behavior is unchanged.

Existing requirement-only profiles are expanded in memory when loaded, so their current choices initially apply to every shield attribute. If a profile contains both formats, explicit attribute-specific choices take precedence. Missing legacy requirement values default to unchecked. Saving the profile writes the new nested structure.

`Other` is the fallback for any shield attribute outside the five normal PvE drop attributes. Existing valuable-item pickup overrides and the existing green-item rules are unchanged.

## Testing

- Ran an AutoIt runtime harness covering all five named attributes, the `Other` fallback, legacy migration, partial legacy settings, and mixed-format precedence.
- Built the loot tree from the shipped default profile in a hidden AutoIt GUI, serialized it, reloaded it, and verified all 1,512 applicable shield attribute/requirement leaves across pickup, salvage, sell, and store.
- Confirmed all four actions use the shared resolver and non-shield weapons retain the old requirement-only path.
- Compared the complete `BotsHub.au3` AutoIt checker output with the same upstream commit. Both report the same existing 44 errors and 72 warnings, with no diagnostics in the new code.
- `git diff --check` passes.