### PR TITLE
feat: Salvage into components option

### DIFF
--- a/BotsHub.au3
+++ b/BotsHub.au3
@@ -147,6 +147,7 @@ $run_options_cache['run.use_consets'] = False
 $run_options_cache['run.use_scrolls'] = False
 $run_options_cache['run.sort_items'] = False
 $run_options_cache['run.farm_materials_mid_run'] = False
+$run_options_cache['run.salvage_into_components'] = False
 $run_options_cache['run.bags_count'] = 5
 $run_options_cache['run.donate_faction_points'] = True
 $run_options_cache['run.buy_faction_scrolls'] = False
@@ -436,6 +437,7 @@ Func ReadConfigFromJson($jsonString)
 	$run_options_cache['run.hard_mode'] = _JSON_Get($jsonObject, 'run.hard_mode')
 	$run_options_cache['run.share_memory'] = _JSON_Get($jsonObject, 'run.share_memory')
 	$run_options_cache['run.farm_materials_mid_run'] = _JSON_Get($jsonObject, 'run.farm_materials_mid_run')
+	$run_options_cache['run.salvage_into_components'] = _JSON_Get($jsonObject, 'run.salvage_into_components')
 	$run_options_cache['run.consume_consumables'] = _JSON_Get($jsonObject, 'run.consume_consumables')
 	$run_options_cache['run.use_consets'] = _JSON_Get($jsonObject, 'run.use_consets')
 	$run_options_cache['run.use_scrolls'] = _JSON_Get($jsonObject, 'run.use_scrolls')
@@ -487,6 +489,7 @@ Func WriteConfigToJson()
 	_JSON_addChangeDelete($jsonObject, 'run.hard_mode', $run_options_cache['run.hard_mode'])
 	_JSON_addChangeDelete($jsonObject, 'run.share_memory', $run_options_cache['run.share_memory'])
 	_JSON_addChangeDelete($jsonObject, 'run.farm_materials_mid_run', $run_options_cache['run.farm_materials_mid_run'])
+	_JSON_addChangeDelete($jsonObject, 'run.salvage_into_components', $run_options_cache['run.salvage_into_components'])
 	_JSON_addChangeDelete($jsonObject, 'run.consume_consumables', $run_options_cache['run.consume_consumables'])
 	_JSON_addChangeDelete($jsonObject, 'run.use_consets', $run_options_cache['run.use_consets'])
 	_JSON_addChangeDelete($jsonObject, 'run.use_scrolls', $run_options_cache['run.use_scrolls'])

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To use it:
 ## Features
 - Unified interface shared by all bots 🖥️
 - Shared inventory, loot, farm, and title tracking 🎯
-- Configurable item handling (pickup, identify, salvage, sell, buy, store) 📦
+- Configurable item handling (pickup, identify, salvage, salvage into components, sell, buy, store) 📦
 - Farm UI with build, equipment, and contextual information 🛡️
 - Modular, plug-and-play bot system 🔌
 

--- a/conf/farm/Default Farm Configuration.json
+++ b/conf/farm/Default Farm Configuration.json
@@ -9,6 +9,7 @@
 		"hard_mode": true,
 		"share_memory": false,
 		"farm_materials_mid_run": false,
+		"salvage_into_components": false,
 		"consume_consumables": true,
 		"use_consets": false,
 		"use_scrolls": false,

--- a/conf/loot/Default Loot Configuration.json
+++ b/conf/loot/Default Loot Configuration.json
@@ -4360,6 +4360,7 @@
 			"Purple": false,
 			"Gold": false
 		},
+		"Upgrade components": true,
 		"Basic Materials": {
 			"Bone": true,
 			"Bolt of Cloth": true,

--- a/lib/BotsHub-GUI.au3
+++ b/lib/BotsHub-GUI.au3
@@ -318,7 +318,6 @@ Func CreateBotsHubGUI()
 	$gui_group_itemoptions = GUICtrlCreateGroup('Inventory management options', 21, 205, 295, 235)
 	$gui_checkbox_sortitems = GUICtrlCreateCheckbox('Sort items', 31, 225)
 	$gui_checkbox_salvageintocomponents = GUICtrlCreateCheckbox('Salvage into components', 31, 255)
-	GUICtrlSetState($gui_checkbox_salvageintocomponents, $GUI_DISABLE)
 	$gui_checkbox_farmmaterialsmidrun = GUICtrlCreateCheckbox('Salvage during run', 31, 285)
 	$gui_label_salvagekits = GUICtrlCreateLabel('Salvage kits:', 31, 318)
 	$gui_combo_salvagekits = GUICtrlCreateCombo('12', 100, 315, 40, 20, BitOR($CBS_DROPDOWNLIST, $WS_VSCROLL))
@@ -352,6 +351,7 @@ Func CreateBotsHubGUI()
 	GUICtrlSetBkColor($gui_renderbutton, $COLOR_YELLOW)
 
 	GUICtrlSetTip($gui_checkbox_farmmaterialsmidrun, 'Salvage items during runs to save space. Bot will take some salvage kits in inventory for that.')
+	GUICtrlSetTip($gui_checkbox_salvageintocomponents, 'Salvage the components ticked in Keep components (mods, inscriptions, runes, insignias) out of items not worth keeping, using expert salvage kits. Salvaged components are then stored.')
 	GUICtrlSetTip($gui_checkbox_useconsumables, 'If bot uses consumables (cake, pie, speed boosts, etc), it will do it automatically.')
 	GUICtrlSetTip($gui_checkbox_useconsets, 'If bot can use consets, it will do it automatically.')
 	GUICtrlSetTip($gui_button_openstorage, 'Open Xunlai storage window. Works remotely - view only from explorable areas.')
@@ -373,6 +373,7 @@ Func CreateBotsHubGUI()
 	GUICtrlSetOnEvent($gui_checkbox_hardmode, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_sharememory, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_farmmaterialsmidrun, 'GuiOptionsHandler')
+	GUICtrlSetOnEvent($gui_checkbox_salvageintocomponents, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_useconsumables, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_useconsets, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_usescrolls, 'GuiOptionsHandler')
@@ -729,6 +730,8 @@ Func GuiOptionsHandler()
 			$run_options_cache['run.share_memory'] = GUICtrlRead($gui_checkbox_sharememory) == $GUI_CHECKED
 		Case $gui_checkbox_farmmaterialsmidrun
 			$run_options_cache['run.farm_materials_mid_run'] = GUICtrlRead($gui_checkbox_farmmaterialsmidrun) == $GUI_CHECKED
+		Case $gui_checkbox_salvageintocomponents
+			$run_options_cache['run.salvage_into_components'] = GUICtrlRead($gui_checkbox_salvageintocomponents) == $GUI_CHECKED
 		Case $gui_checkbox_useconsumables
 			$run_options_cache['run.consume_consumables'] = GUICtrlRead($gui_checkbox_useconsumables) == $GUI_CHECKED
 		Case $gui_checkbox_useconsets
@@ -1683,6 +1686,7 @@ Func ApplyConfigToGUI()
 	GUICtrlSetState($gui_checkbox_hardmode, $run_options_cache['run.hard_mode'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_sharememory, $run_options_cache['run.share_memory'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_farmmaterialsmidrun, $run_options_cache['run.farm_materials_mid_run'] ? $GUI_CHECKED : $GUI_UNCHECKED)
+	GUICtrlSetState($gui_checkbox_salvageintocomponents, $run_options_cache['run.salvage_into_components'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_useconsumables, $run_options_cache['run.consume_consumables'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_useconsets, $run_options_cache['run.use_consets'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_usescrolls, $run_options_cache['run.use_scrolls'] ? $GUI_CHECKED : $GUI_UNCHECKED)

--- a/lib/Utils-Items_Modstructs.au3
+++ b/lib/Utils-Items_Modstructs.au3
@@ -1099,6 +1099,42 @@ Func ContainsValuableUpgrades($item)
 EndFunc
 
 
+;~ Returns the salvage slot indices (prefix/insignia 0, suffix/rune 1, inscription 2) of the components worth keeping in the item
+;~ Same detection as ContainsValuableUpgrades, split by slot so the right component can be salvaged out of the item
+Func GetValuableComponentIndices($item)
+	Local $indices[0]
+	Local $modStruct = GetModStruct($item)
+	If Not $modStruct Then Return $indices
+	If IsWeapon($item) Then
+		Local $itemType = DllStructGetData($item, 'type')
+		If ContainsAnyStruct($modStruct, $valuable_prefix_mods_by_weapon_type[$itemType], $STRUCT_WEAPON_UPGRADE) Then _ArrayAdd($indices, $COMPONENT_INDEX_PREFIX)
+		If ContainsAnyStruct($modStruct, $valuable_suffix_mods_by_weapon_type[$itemType], $STRUCT_WEAPON_UPGRADE) Then _ArrayAdd($indices, $COMPONENT_INDEX_SUFFIX)
+		If IsInscribable($item) And ContainsAnyStruct($modStruct, $valuable_inscriptions_by_weapon_type[$itemType], $STRUCT_INSCRIPTION) Then _ArrayAdd($indices, $COMPONENT_INDEX_INSCRIPTION)
+	ElseIf IsArmorSalvageItem($item) Then
+		If ContainsAnyStruct($modStruct, $valuable_insignias_structs_array) Then _ArrayAdd($indices, $COMPONENT_INDEX_PREFIX)
+		If ContainsAnyStruct($modStruct, $valuable_runes_structs_array) Then _ArrayAdd($indices, $COMPONENT_INDEX_SUFFIX)
+	EndIf
+	Return $indices
+EndFunc
+
+
+;~ Returns true if the modstruct contains one of the given structs - when a header is given, only structs preceded by it count
+;~ Header is the byte in front of the struct: $STRUCT_WEAPON_UPGRADE for weapon mods, $STRUCT_INSCRIPTION for inscriptions
+Func ContainsAnyStruct($modStruct, $structs, $header = Null)
+	If Not IsArray($structs) Then Return False
+	For $struct In $structs
+		If Not IsString($struct) Or $struct == '' Then ContinueLoop
+		Local $upgradePosition = StringInStr($modStruct, $struct)
+		While $upgradePosition > 0
+			If $header == Null Then Return True
+			If $upgradePosition >= 5 And StringMid($modStruct, $upgradePosition - 4, 2) == $header Then Return True
+			$upgradePosition = StringInStr($modStruct, $struct, 0, 1, $upgradePosition + 1)
+		WEnd
+	Next
+	Return False
+EndFunc
+
+
 ;~ Determines whether the provided OS (Old School) item has perfect mods
 Func HasPerfectMods($item)
 	Local $itemType	= DllStructGetData($item, 'type')
@@ -1153,12 +1189,27 @@ Global $valuable_inscriptions_array[]
 Global $valuable_inscriptions_by_weapon_type			= DefaultCreateValuableInscriptionsByWeaponTypeMap()
 
 
+; Salvage slot indices used to salvage a component out of an item: prefix/insignia 0, suffix/rune 1, inscription 2
+Global Const $COMPONENT_INDEX_PREFIX = 0
+Global Const $COMPONENT_INDEX_SUFFIX = 1
+Global Const $COMPONENT_INDEX_INSCRIPTION = 2
+; Valuable components split by salvage slot - filled from the loot configuration, used to salvage components out of items
+Global $valuable_prefix_mods_by_weapon_type[]
+Global $valuable_suffix_mods_by_weapon_type[]
+Global $valuable_insignias_structs_array[]
+Global $valuable_runes_structs_array[]
+
+
 ;~ Replace valuable runes/insignias/inscriptions/mods default lists by the lists of elements present in cache
 Func RefreshValuableListsFromCache()
 	$valuable_runes_and_insignias_structs_array = CreateValuableRunesAndInsigniasArray()
 	;$valuable_mods_by_os_weapon_type = CreateValuableModsByOSWeaponTypeMap()
 	$valuable_mods_by_weapon_type = CreateValuableModsByWeaponTypeMap()
 	$valuable_inscriptions_by_weapon_type = CreateValuableInscriptionsByWeaponTypeMap()
+	$valuable_prefix_mods_by_weapon_type = CreateValuableModsBySlotByWeaponTypeMap('Prefix')
+	$valuable_suffix_mods_by_weapon_type = CreateValuableModsBySlotByWeaponTypeMap('Suffix')
+	$valuable_insignias_structs_array = CreateValuableArmorUpgradesArray('Insignias')
+	$valuable_runes_structs_array = CreateValuableArmorUpgradesArray('Runes')
 EndFunc
 
 
@@ -1173,6 +1224,22 @@ Func CreateValuableRunesAndInsigniasArray()
 		$valuableRunesAndInsigniasStructsArray[$i] = SafeEval($varName)
 	Next
 	Return $valuableRunesAndInsigniasStructsArray
+EndFunc
+
+
+;~ Creates an array of the valuable armor upgrades of one category ('Insignias' or 'Runes') based on selected elements in treeview
+;~ Insignias sit at salvage index 0 and runes at index 1 of their armor salvageable item, hence the split
+Func CreateValuableArmorUpgradesArray($category)
+	Local $tickedRunesAndInsignias = GetAllChecked($inventory_management_cache, 'Keep components.Armor upgrades', 3, 3)
+	Local $valuableStructsArray[0]
+	For $tickedElement In $tickedRunesAndInsignias
+		If Not StringInStr($tickedElement, '.' & $category & '.') Then ContinueLoop
+		; removing leftmost string with dot 'Keep components.Armor upgrades.'
+		Local $varName = StringTrimLeft($tickedElement, 31)
+		$varName = 'Struct_' & StringReplace(StringReplace($varName, '.', '_'), ' ', '_')
+		_ArrayAdd($valuableStructsArray, SafeEval($varName))
+	Next
+	Return $valuableStructsArray
 EndFunc
 
 
@@ -1332,6 +1399,28 @@ Func CreateValuableInscriptionsByWeaponTypeMap()
 		EndSwitch
 	Next
 	Return $inscriptionsByWeaponType
+EndFunc
+
+
+;~ Creates a map of the valuable weapon mods of one salvage slot ('Prefix' or 'Suffix') by weapon type based on selected elements in treeview
+;~ Same elements as CreateValuableModsByWeaponTypeMap, split by slot so the right component can be salvaged out of an item
+Func CreateValuableModsBySlotByWeaponTypeMap($slotName)
+	Local $weaponModsByType[]
+	For $weaponType In $WEAPON_TYPES_ARRAY
+		Local $weaponName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
+		Local $modsPath = 'Keep components.Mods.' & $weaponName & '.'
+		Local $tickedMods = GetAllChecked($inventory_management_cache, 'Keep components.Mods.' & $weaponName, 2, 2)
+		Local $mods[0]
+		For $tickedMod In $tickedMods
+			; Relative path looks like 'Prefix - Haft.Sundering (Armor penetration +20% - Chance 20%)'
+			Local $relativePath = StringTrimLeft($tickedMod, StringLen($modsPath))
+			If StringLeft($relativePath, StringLen($slotName)) <> $slotName Then ContinueLoop
+			Local $modName = StringTrimLeft($relativePath, StringInStr($relativePath, '.'))
+			_ArrayAdd($mods, SafeEval('STRUCT_MOD_' & ModNameCleanupHelper($modName)))
+		Next
+		$weaponModsByType[$weaponType] = $mods
+	Next
+	Return $weaponModsByType
 EndFunc
 #EndRegion Structure creation from UI
 

--- a/lib/Utils-Storage.au3
+++ b/lib/Utils-Storage.au3
@@ -45,12 +45,13 @@ Func InventoryManagementBeforeRun()
 	; 2-Sort items
 	; 3-Identify items
 	; 4-Collect data
-	; 5-Salvage
-	; 6-Sell materials
-	; 7-Sell items
-	; 8-Balance character gold level
-	; 9-Buy ectoplasm/obsidian with surplus
-	; 10-Store items
+	; 5-Salvage valuable components out of items not worth keeping
+	; 6-Salvage
+	; 7-Sell materials
+	; 8-Sell items
+	; 9-Balance character gold level
+	; 10-Buy ectoplasm/obsidian with surplus
+	; 11-Store items
 	If $cache['Store items.Unidentified gold items'] And HasGoldUnidentifiedItems() Then
 		If GetMapType() <> $ID_OUTPOST Then TravelToOutpost($trade_town, $district_name)
 		StoreItemsInXunlaiStorage(IsUnidentifiedGoldItem)
@@ -68,11 +69,14 @@ Func InventoryManagementBeforeRun()
 		StoreAllItemsData()
 		DisconnectFromDatabase()
 	EndIf
+	If $run_options_cache['run.salvage_into_components'] And HasComponentsToSalvage() Then
+		TravelToOutpost($trade_town, $district_name)
+		SalvageComponents()
+	EndIf
 	If $cache['@salvage.something'] And HasItemsToSalvage() Then
 		TravelToOutpost($trade_town, $district_name)
 		SalvageItems()
 		If $bags_count == 5 And MoveItemsOutOfEquipmentBag() > 0 Then SalvageItems()
-		;SalvageInscriptions()
 		;UpgradeWithSalvageInscriptions()
 		;SalvageMaterials()
 	EndIf
@@ -123,7 +127,8 @@ Func InventoryManagementMidRun()
 	; 2-If not, buy until we have 4 identification kits and 12 salvaged kits
 	; 3-Sort items
 	; 4-Identify items
-	; 5-Salvage
+	; 5-Salvage valuable components out of items if an expert salvage kit is available
+	; 6-Salvage
 	Local Static $superiorIdentificationKits = [$ID_INFINITE_IDENTIFICATION_KIT, $ID_SUPERIOR_IDENTIFICATION_KIT]
 	Local Static $salvageKits = [$ID_SALVAGE_KIT, $ID_SALVAGE_KIT_2]
 	If GetInventoryKitCount($superiorIdentificationKits) < 1 Or GetInventoryKitCount($salvageKits) < 1 Then
@@ -136,6 +141,7 @@ Func InventoryManagementMidRun()
 	EndIf
 	If $run_options_cache['run.sort_items'] Then SortInventory()
 	If $inventory_management_cache['@identify.something'] And HasUnidentifiedItems() Then IdentifyItems(False)
+	If $run_options_cache['run.salvage_into_components'] Then SalvageComponents(False)
 	If $inventory_management_cache['@salvage.something'] Then
 		SalvageItems(False)
 		If $bags_count == 5 And MoveItemsOutOfEquipmentBag() > 0 Then SalvageItems(False)
@@ -466,6 +472,22 @@ Func DefaultShouldSalvageItem($item)
 EndFunc
 
 
+;~ Return True if valuable components (mods, inscriptions, runes, insignias) should be salvaged out of the item
+;~ Only items not worth keeping for themselves are stripped, so weapons kept for their skin, req or stats stay untouched
+Func ShouldSalvageComponents($item)
+	If DllStructGetData($item, 'ID') = 0 Then Return False
+	If GetRarity($item) == $RARITY_GREEN Then Return False
+	If Not IsIdentified($item) Then Return False
+	If IsWeapon($item) Then
+		If Not DllStructGetData($item, 'IsMaterialSalvageable') Then Return False
+		If ShouldKeepWeapon($item, False) Then Return False
+	ElseIf Not IsArmorSalvageItem($item) Then
+		Return False
+	EndIf
+	Return UBound(GetValuableComponentIndices($item)) > 0
+EndFunc
+
+
 ;~ Return True if the item should be sold to the merchant - default to false
 Func DefaultShouldSellItem($item)
 	; Clarity rename
@@ -541,6 +563,11 @@ Func DefaultShouldStoreItem($item)
 		Local $rarityName = $RARITY_NAMES_FROM_IDS[$rarity]
 		;Return ContainsValuableUpgrades($item)
 		Return $cache['Store items.Armor salvageables.' & $rarityName]
+	; ----------------------------------- Upgrade components -----------------------------------
+	ElseIf IsUpgradeComponent($item) Then
+		Local $shouldStore = $cache['Store items.Upgrade components']
+		; Loot configurations saved before this option existed have no value for it: store components when the bot salvages them
+		Return $shouldStore == Null ? $run_options_cache['run.salvage_into_components'] : $shouldStore
 	; ------------------------------------- Consumables -------------------------------------
 	ElseIf IsAlcohol($itemID) Then
 		If $MAP_MINOR_ALCOHOLS[$itemID] <> Null Then Return $cache['Store items.Alcohols.Minor (1pt)']
@@ -614,8 +641,8 @@ Func DefaultShouldStoreItem($item)
 EndFunc
 
 
-;~ Return True if weapon item should not be sold or salvaged
-Func ShouldKeepWeapon($item)
+;~ Return True if weapon item should not be sold or salvaged - $checkUpgrades False ignores the components it contains
+Func ShouldKeepWeapon($item, $checkUpgrades = True)
 	Local Static $lowReqValuableWeaponTypes = [$ID_TYPE_SWORD, $ID_TYPE_OFFHAND, $ID_TYPE_SHIELD, $ID_TYPE_DAGGER, $ID_TYPE_SCYTHE, $ID_TYPE_SPEAR]
 	Local Static $lowReqValuableWeaponTypesMap = MapFromArray($lowReqValuableWeaponTypes)
 	Local Static $valuableOSWeaponTypes = [$ID_TYPE_SHIELD, $ID_TYPE_OFFHAND, $ID_TYPE_WAND]
@@ -637,7 +664,7 @@ Func ShouldKeepWeapon($item)
 	; Keeping super-rare items, good in all cases, items (BDS, voltaic, etc)
 	If $MAP_ULTRA_RARE_WEAPONS[$itemID] <> Null Then Return True
 	; Keeping items that contain good upgrades
-	If ContainsValuableUpgrades($item) Then Return True
+	If $checkUpgrades And ContainsValuableUpgrades($item) Then Return True
 	; Throwing items without good damage/energy/armor
 	If Not IsMaxStatsForReq($item) Then Return False
 	; Inscribable are kept only if : 1) rare skin and q9 2) low Req of a good type
@@ -1045,6 +1072,8 @@ Func BuyKitsForMidRun()
 
 	If $salvageKitsRequired > 0 Then BuySalvageKitInTown($salvageKitsRequired)
 	If $identificationKitsRequired > 0 Then BuySuperiorIdentificationKitInTown($identificationKitsRequired)
+	; Salvaging components needs an expert salvage kit - keep one in inventory when the option is enabled
+	If $run_options_cache['run.salvage_into_components'] And FindSalvageKit() == Null Then BuyExpertSalvageKitInTown()
 EndFunc
 #EndRegion Buying/selling items from/to merchant
 
@@ -1328,6 +1357,31 @@ Func GetSalvageKit($buyKit = True)
 EndFunc
 
 
+;~ Returns an expert or superior salvage kit, buying an expert one in town if needed and allowed - required to salvage components
+Func GetExpertSalvageKit($buyKit = True)
+	Local $kit = FindSalvageKit()
+	If $kit == Null And $buyKit Then
+		BuyExpertSalvageKitInTown()
+		$kit = FindSalvageKit()
+	EndIf
+	Return $kit
+EndFunc
+
+
+;~ Returns the remaining uses of a salvage kit - kits sell back for a fixed price per remaining use
+Func GetSalvageKitUses($kit)
+	Local $value = DllStructGetData($kit, 'Value')
+	Switch DllStructGetData($kit, 'ModelID')
+		Case $ID_EXPERT_SALVAGE_KIT
+			Return $value / 8
+		Case $ID_SUPERIOR_SALVAGE_KIT
+			Return $value / 10
+		Case Else
+			Return $value / 2
+	EndSwitch
+EndFunc
+
+
 ;~ Salvage an item based on its position in the inventory
 Func SalvageItemAt($bagIndex, $slot)
 	Local $item = GetItemBySlot($bagIndex, $slot)
@@ -1362,6 +1416,88 @@ Func SalvageItem($item, $salvageKit, $salvageType = 'Materials')
 			Return False
 	EndSwitch
 	PingSleep(50)
+	Return True
+EndFunc
+
+
+;~ Salvage valuable components (mods, inscriptions, runes, insignias) out of the items not worth keeping for themselves
+;~ Needs an expert or superior salvage kit - the stripped item then goes through the usual salvage/sell flow
+;~ Salvaging a component can destroy the item, so it is re-read from its slot after each salvage
+;~ With $dryRun, only logs what would be salvaged
+Func SalvageComponents($buyKit = True, $dryRun = False)
+	; A weapon holds at most a prefix, a suffix and an inscription
+	Local Static $maxComponentsPerItem = 3
+	Info('Salvaging components out of items')
+	Local $kit = Null
+	Local $uses = 0
+	If Not $dryRun Then
+		$kit = GetExpertSalvageKit($buyKit)
+		If $kit == Null Then
+			Warn('No expert salvage kit available to salvage components')
+			Return False
+		EndIf
+		$uses = GetSalvageKitUses($kit)
+	EndIf
+
+	For $bagIndex = 1 To $bags_count
+		Local $bagSize = DllStructGetData(GetBag($bagIndex), 'slots')
+		For $slot = 1 To $bagSize
+			Local $item = GetItemBySlot($bagIndex, $slot)
+			If Not ShouldSalvageComponents($item) Then ContinueLoop
+			Local $itemID = DllStructGetData($item, 'ID')
+			Local $attempts = 0
+			While $attempts < $maxComponentsPerItem
+				Local $indices = GetValuableComponentIndices($item)
+				If UBound($indices) == 0 Then ExitLoop
+				If $dryRun Then
+					Info('Would salvage components ' & _ArrayToString($indices, ', ') & ' out of item at ' & $bagIndex & ':' & $slot)
+					ExitLoop
+				EndIf
+				; Each salvaged component needs a free slot, and the item may survive the salvage
+				If CountSlots(1, _Min(4, $bags_count)) < 1 Then
+					Warn('No space left in inventory to salvage more components')
+					Return True
+				EndIf
+				Debug('Salvaging component ' & $indices[0] & ' out of item at ' & $bagIndex & ':' & $slot)
+				Local $modStructBefore = GetModStruct($item)
+				SalvageComponent($item, $kit, $indices[0])
+				$attempts += 1
+				$uses -= 1
+				If $uses < 1 Then
+					$kit = GetExpertSalvageKit($buyKit)
+					If $kit == Null Then Return False
+					$uses = GetSalvageKitUses($kit)
+				EndIf
+				; The salvage might have destroyed the item - stop if it is gone or replaced
+				$item = GetItemBySlot($bagIndex, $slot)
+				If DllStructGetData($item, 'ID') <> $itemID Then ExitLoop
+				If GetModStruct($item) == $modStructBefore Then
+					Warn('Salvaging a component did not change the item at ' & $bagIndex & ':' & $slot & ', skipping it')
+					ExitLoop
+				EndIf
+			WEnd
+		Next
+	Next
+	Return True
+EndFunc
+
+
+;~ Salvage the component at the given index (prefix/insignia 0, suffix/rune 1, inscription 2) out of the given item
+;~ Needs an expert or superior salvage kit: the game opens a choice window for those, and the packets answer it directly
+Func SalvageComponent($item, $salvageKit, $componentIndex)
+	Local $rarity = GetRarity($item)
+	While Not StartSalvageWithKit($item, $salvageKit)
+		PingSleep(50)
+	WEnd
+	PingSleep(600)
+	If $rarity == $RARITY_GOLD Or $rarity == $RARITY_PURPLE Then
+		ValidateSalvage()
+		PingSleep(600)
+	EndIf
+	SalvageMod($componentIndex)
+	PingSleep(600)
+	EndSalvage()
+	PingSleep(300)
 	Return True
 EndFunc
 #EndRegion Salvage
@@ -1789,6 +1925,12 @@ EndFunc
 ;~ Returns true if there are items in inventory that user selected to salvage in the GUI interface
 Func HasItemsToSalvage($shouldSalvageItem = DefaultShouldSalvageItem)
 	Return HasInInventory($shouldSalvageItem)
+EndFunc
+
+
+;~ Returns true if there are items in inventory with valuable components to salvage out
+Func HasComponentsToSalvage()
+	Return HasInInventory(ShouldSalvageComponents)
 EndFunc
 
 
@@ -2394,6 +2536,12 @@ EndFunc
 ;~ Return true if the item is a weapon mod
 Func IsWeaponMod($itemID)
 	Return $MAP_WEAPON_MODS[$itemID] <> Null
+EndFunc
+
+
+;~ Return true if the item is an upgrade component: weapon mod, inscription, rune or insignia
+Func IsUpgradeComponent($item)
+	Return DllStructGetData($item, 'type') == $ID_TYPE_UPGRADE
 EndFunc
 
 

--- a/src/utilities/TestSuite.au3
+++ b/src/utilities/TestSuite.au3
@@ -40,6 +40,7 @@ Global Const $HERO_TO_ADD = $ID_HAYDA
 ;~ Main method from utils, used only to run tests
 Func RunTests()
 	;SellItemsToMerchant(DefaultShouldSellItem, True)
+	;SalvageComponents(False, True)
 
 	; To run some mapping, uncomment the following line, and set the path to the file that will contain the mapping
 	;ToggleMapping(1, @ScriptDir & '/logs/fow_mapping.log')


### PR DESCRIPTION
## Summary

New inventory option **Salvage into components** (Options tab, `run.salvage_into_components`, default off). When enabled, the valuable mods, inscriptions, runes and insignias are salvaged out of items that are not worth keeping for themselves, the components are stored like other valuables, and the stripped item then goes through the usual salvage/sell flow.

- Component detection reuses the *Keep components* selections of the loot configuration, split by salvage slot (prefix/insignia 0, suffix/rune 1, inscription 2): `GetValuableComponentIndices`, `ContainsAnyStruct`, `CreateValuableArmorUpgradesArray`, `CreateValuableModsBySlotByWeaponTypeMap`.
- `ShouldSalvageComponents` only strips items failing the keep rules; `ShouldKeepWeapon` gains a `$checkUpgrades` switch so weapons kept for their skin, requirement or stats stay untouched.
- Needs an expert or superior salvage kit: `GetExpertSalvageKit` buys an expert kit in town when needed and allowed, `GetSalvageKitUses` reads the remaining uses. The kit choice window is answered directly by packets in `SalvageComponent`.
- Salvaging a component can destroy the item, so it is re-read from its slot after each salvage. `SalvageComponents($buyKit, $dryRun)` has a dry-run mode that only logs what would be salvaged (`;SalvageComponents(False, True)` left in the test suite).
- In town the routine runs when `HasComponentsToSalvage()`; mid-run it runs without buying kits.
- The previously disabled GUI checkbox is now active with a tooltip; default farm and loot configurations, JSON read/write and README updated.

## Test plan

- [ ] Tick *Salvage into components*, run a farm dropping modded items, check that only items failing the keep rules are stripped and that the components reach storage
- [ ] Start without an expert kit in town and check one is bought; check nothing is bought mid-run
- [ ] Run `SalvageComponents(False, True)` from the test suite and review the dry-run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
