### PR TITLE
feat: Build-aware combat routine for Assassin's Promise builds (Me/A, N/A, E/A)

### DIFF
--- a/BotsHub.au3
+++ b/BotsHub.au3
@@ -49,6 +49,7 @@ Opt('MustDeclareVars', True)
 #include 'lib/Utils-Shared_Memory.au3'
 #include 'lib/Utils-Storage.au3'
 #include 'lib/Build_PW_Heroic-Refrain.au3'
+#include 'lib/Build_XA_Assassins-Promise.au3'
 
 #include 'src/farms/CoF.au3'
 #include 'src/farms/Corsairs.au3'
@@ -154,6 +155,7 @@ $run_options_cache['run.buy_faction_resources'] = False
 $run_options_cache['run.collect_data'] = False
 $run_options_cache['run.go_offline'] = False
 $run_options_cache['run.flash_whisper'] = False
+$run_options_cache['run.smart_assassins_promise'] = True
 $run_options_cache['team.automatic_team_setup'] = False
 ; Overrides on $run_options_cache for frequent usage
 Global $district_name = 'Default'
@@ -444,6 +446,9 @@ Func ReadConfigFromJson($jsonString)
 	$run_options_cache['run.collect_data'] = _JSON_Get($jsonObject, 'run.collect_data')
 	$run_options_cache['run.go_offline'] = _JSON_Get($jsonObject, 'run.go_offline')
 	$run_options_cache['run.flash_whisper'] = _JSON_Get($jsonObject, 'run.flash_whisper')
+	; Older configuration files do not have this key - smart casting is enabled by default
+	Local $smartAssassinsPromise = _JSON_Get($jsonObject, 'run.smart_assassins_promise')
+	$run_options_cache['run.smart_assassins_promise'] = @error ? True : $smartAssassinsPromise
 	$run_options_cache['run.donate_faction_points'] = _JSON_Get($jsonObject, 'run.donate_faction_points')
 	$run_options_cache['run.buy_faction_resources'] = _JSON_Get($jsonObject, 'run.buy_faction_resources')
 	$run_options_cache['run.buy_faction_scrolls'] = _JSON_Get($jsonObject, 'run.buy_faction_scrolls')
@@ -494,6 +499,7 @@ Func WriteConfigToJson()
 	_JSON_addChangeDelete($jsonObject, 'run.collect_data', $run_options_cache['run.collect_data'])
 	_JSON_addChangeDelete($jsonObject, 'run.go_offline', $run_options_cache['run.go_offline'])
 	_JSON_addChangeDelete($jsonObject, 'run.flash_whisper', $run_options_cache['run.flash_whisper'])
+	_JSON_addChangeDelete($jsonObject, 'run.smart_assassins_promise', $run_options_cache['run.smart_assassins_promise'])
 	_JSON_addChangeDelete($jsonObject, 'run.donate_faction_points', $run_options_cache['run.donate_faction_points'])
 	_JSON_addChangeDelete($jsonObject, 'run.buy_faction_resources', $run_options_cache['run.buy_faction_resources'])
 	_JSON_addChangeDelete($jsonObject, 'run.buy_faction_scrolls', $run_options_cache['run.buy_faction_scrolls'])
@@ -694,11 +700,22 @@ EndFunc
 
 ;~ Auto-detect player build and wire up specialized combat/maintenance routines
 Func SetupPlayerBuildOverrides()
+	; Start from the default combat routine so a previous build override does not linger
+	$default_move_aggro_kill_options['killMethod']	= UseSkillSequentially
+	$flag_move_aggro_kill_options['killMethod']		= UseSkillSequentially
+	$optionsFollower['killMethod']					= UseSkillSequentially
+
 	; For build detection, we iterate over skills and key skills + profession will give use which build must be used
 	Local $profession = GetHeroProfession(0)
 	Local $skillbar = GetSkillbar(0)
 	For $i = 1 To 8
 		Local $skillID = DllStructGetData($skillbar, 'SkillID' & $i)
+		; Builds recognised whatever the primary profession
+		If $skillID == $ID_ASSASSINS_PROMISE Then
+			If $run_options_cache['run.smart_assassins_promise'] Then Return SetupAPBuild()
+			Info('Assassin''s Promise is on the skillbar but smart casting is disabled - skills will be used from 1 to 8')
+			Return
+		EndIf
 		If $profession == $ID_PARAGON Then
 			If $skillID == $ID_HEROIC_REFRAIN Then Return SetupHRBuild()
 			;If $skillID == ... Then Return ...

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To use it:
 - Shared inventory, loot, farm, and title tracking 🎯
 - Configurable item handling (pickup, identify, salvage, sell, buy, store) 📦
 - Farm UI with build, equipment, and contextual information 🛡️
+- Build-aware combat when a known player build is detected (Heroic Refrain, Assassin's Promise) 🧠
 - Modular, plug-and-play bot system 🔌
 
 ---
@@ -79,6 +80,8 @@ To use it:
 | Dalada Uplands				| Vanguard								|
 | Secret Lair of the Snowmen	| Deldrimor								|
 | Pre-Searing					| Legendary Defender of Ascalon (LDOA)	|
+
+Vanquish, dungeon and title bots play whatever build the character carries. With an Assassin's Promise build (Me/A, N/A, E/A) the bot uses a dedicated casting routine: Assassin's Promise once the target is close to 50% health, "Finish Him!" under 50%, "You Move Like a Dwarf!" to finish, Ebon Vanguard Assassin Support otherwise, and the mesmer's Arcane Echo and Auspicious Incantation only where they pay off. Untick *Smart Assassin's Promise casting* in the Team tab to fall back to casting skills from 1 to 8.
 
 ### Dungeons / Elite Zones
 

--- a/conf/farm/Default Farm Configuration.json
+++ b/conf/farm/Default Farm Configuration.json
@@ -22,7 +22,8 @@
 		"district": "Default",
 		"disable_rendering": false,
 		"go_offline": false,
-		"flash_whisper": false
+		"flash_whisper": false,
+		"smart_assassins_promise": true
 	},
 	"team": {
 		"automatic_team_setup": false,

--- a/lib/BotsHub-GUI.au3
+++ b/lib/BotsHub-GUI.au3
@@ -145,7 +145,7 @@ Global $gui_group_teamoptions, $gui_teamlabel, $gui_teammemberlabel, $gui_teamme
 		$gui_checkbox_load_build_hero_4, $gui_checkbox_load_build_hero_5, $gui_checkbox_load_build_hero_6, $gui_checkbox_load_build_hero_7, _
 		$gui_label_build_hero_1, $gui_label_build_hero_2, $gui_label_build_hero_3, $gui_label_build_hero_4, $gui_label_build_hero_5, $gui_label_build_hero_6, $gui_label_build_hero_7, _
 		$gui_input_build_player, $gui_input_build_hero_1, $gui_input_build_hero_2, $gui_input_build_hero_3, $gui_input_build_hero_4, $gui_input_build_hero_5, $gui_input_build_hero_6, $gui_input_build_hero_7
-Global $gui_group_otheroptions, $gui_button_openstorage, $gui_checkbox_gooffline, $gui_checkbox_flashwhisper
+Global $gui_group_otheroptions, $gui_button_openstorage, $gui_checkbox_gooffline, $gui_checkbox_flashwhisper, $gui_checkbox_smartassassinspromise
 Global $gui_label_characterbuilds, $gui_label_heroesbuilds, $gui_edit_characterbuilds, $gui_edit_heroesbuilds, $gui_label_farminformations
 Global $gui_treeview_lootoptions, $gui_label_lootoptionswarning, $gui_expandlootoptionsbutton, $gui_reducelootoptionsbutton, $gui_loadlootoptionsbutton, $gui_savelootoptionsbutton, $gui_applylootoptionsbutton
 
@@ -413,6 +413,9 @@ Func CreateBotsHubGUI()
 		'- correct behaviour (passive/aggressive)' & @CRLF & _
 		'If party size is 4 or 6, last heroes just will not be added to party.', 40, 70)
 	$gui_checkbox_automaticteamsetup = GUICtrlCreateCheckbox('Setup team automatically using team options section', 31, 140)
+	$gui_checkbox_smartassassinspromise = GUICtrlCreateCheckbox('Smart Assassin''s Promise casting', 375, 140)
+	GUICtrlSetTip($gui_checkbox_smartassassinspromise, 'When Assassin''s Promise is on the player skillbar, fights use a build-aware casting routine: Promise once the target nears 50% health, "Finish Him!" under 50%, "You Move Like a Dwarf!" to finish, Ebon Vanguard Assassin Support otherwise, mesmer Arcane Echo and Auspicious Incantation only where they pay off. Untick to cast skills from 1 to 8 instead.')
+	GUICtrlSetOnEvent($gui_checkbox_smartassassinspromise, 'GuiOptionsHandler')
 	$gui_teammemberlabel = GUICtrlCreateLabel('Team member', 147, 170, 100, 20)
 	$gui_teammemberbuildlabel = GUICtrlCreateLabel('Team member build', 445, 170, 100, 20)
 	$gui_checkbox_load_build_all = GUICtrlCreateCheckbox('Load all builds:', 254, 167)
@@ -739,6 +742,8 @@ Func GuiOptionsHandler()
 			$run_options_cache['run.go_offline'] = GUICtrlRead($gui_checkbox_gooffline) == $GUI_CHECKED
 		Case $gui_checkbox_flashwhisper
 			$run_options_cache['run.flash_whisper'] = GUICtrlRead($gui_checkbox_flashwhisper) == $GUI_CHECKED
+		Case $gui_checkbox_smartassassinspromise
+			$run_options_cache['run.smart_assassins_promise'] = GUICtrlRead($gui_checkbox_smartassassinspromise) == $GUI_CHECKED
 		Case $gui_checkbox_sortitems
 			$run_options_cache['run.sort_items'] = GUICtrlRead($gui_checkbox_sortitems) == $GUI_CHECKED
 		Case $gui_checkbox_collectdata
@@ -936,7 +941,7 @@ Func UpdateFarmDescription($farm)
 	GUICtrlSetData($gui_edit_heroesbuilds, '')
 	GUICtrlSetData($gui_label_farminformations, '')
 
-	Local $generalCharacterSetup = 'Simple build to play from skill 1 to skill 8, such as:' & @CRLF & _
+	Local $generalCharacterSetup = 'Assassin''s Promise builds are played with a dedicated casting routine (see the Team tab option), other builds from skill 1 to skill 8. Suggested builds:' & @CRLF & _
 		'https://gwpvx.fandom.com/wiki/Build:N/A_Assassin%27s_Promise_Death_Magic' & @CRLF & _
 		'https://gwpvx.fandom.com/wiki/Build:E/A_Assassin%27s_Promise' & @CRLF & _
 		'https://gwpvx.fandom.com/wiki/Build:Me/A_Assassin%27s_Promise'
@@ -1688,6 +1693,7 @@ Func ApplyConfigToGUI()
 	GUICtrlSetState($gui_checkbox_usescrolls, $run_options_cache['run.use_scrolls'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_gooffline, $run_options_cache['run.go_offline'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_flashwhisper, $run_options_cache['run.flash_whisper'] ? $GUI_CHECKED : $GUI_UNCHECKED)
+	GUICtrlSetState($gui_checkbox_smartassassinspromise, $run_options_cache['run.smart_assassins_promise'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_sortitems, $run_options_cache['run.sort_items'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_collectdata, $run_options_cache['run.collect_data'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_radiobutton_donatepoints, $run_options_cache['run.donate_faction_points'] ? $GUI_CHECKED : $GUI_UNCHECKED)

--- a/lib/Build_XA_Assassins-Promise.au3
+++ b/lib/Build_XA_Assassins-Promise.au3
@@ -1,0 +1,345 @@
+#CS ===========================================================================
+; Author: caustic-kronos (aka Kronos, Night, Svarog)
+; Copyright 2026 caustic-kronos
+;
+; Licensed under the Apache License, Version 2.0 (the 'License');
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an 'AS IS' BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+#CE ===========================================================================
+
+#include-once
+#include 'GWA2.au3'
+#include 'GWA2_ID.au3'
+#include 'GWA2_ID_Skills.au3'
+#include 'Utils.au3'
+#include 'Utils-Agents.au3'
+
+; ============================================================================
+; Assassin's Promise build support - any primary profession with /A secondary
+;
+; https://gwpvx.fandom.com/wiki/Build:Me/A_Assassin%27s_Promise
+; https://gwpvx.fandom.com/wiki/Build:N/A_Assassin%27s_Promise_Death_Magic
+; https://gwpvx.fandom.com/wiki/Build:E/A_Assassin%27s_Promise
+;
+; Call SetupAPBuild() once during setup - SetupPlayerBuildOverrides does it automatically
+; when Assassin's Promise is found on the skillbar. The combat routine APCombat then
+; replaces the "cast from skill 1 to 8" routine on the move-aggro-kill option maps.
+;
+; Casting rules, one skill per loop iteration, highest priority first:
+;	1. Assassin's Promise once the target is at or below $AP_CAST_HEALTH_THRESHOLD
+;	   Never while Auspicious Incantation or Arcane Echo wait for a spell that Ebon Vanguard Assassin Support can provide
+;	2. "Finish Him!" once the target is below 50% - it has no effect above that
+;	3. "You Move Like a Dwarf!" after "Finish Him!" was used on the target, or when "Finish Him!" cannot be used,
+;	   or when its damage would bring the target below 50% while keeping enough energy for "Finish Him!"
+;	4. Mesmer: Auspicious Incantation, then Arcane Echo, then Ebon Vanguard Assassin Support and its echoed copy
+;	   Auspicious Incantation is only cast when Arcane Echo or Ebon Vanguard Assassin Support will consume it
+;	   Arcane Echo is only cast when Ebon Vanguard Assassin Support can follow immediately
+;	5. Ebon Vanguard Assassin Support
+;	6. Any other skill on the bar, from left to right, keeping an energy reserve for one shout
+;
+; Any non-spell skill ends Arcane Echo, so shouts are never used while Arcane Echo waits for
+; a spell or holds an unused copy of Ebon Vanguard Assassin Support.
+; ============================================================================
+
+; Tunables
+Global Const $AP_CAST_HEALTH_THRESHOLD			= 0.6	; Assassin's Promise is cast at or below this target health fraction
+Global Const $AP_FINISH_HIM_HEALTH_THRESHOLD	= 0.5	; "Finish Him!" has no effect at or above this target health fraction
+Global Const $AP_FILLER_ENERGY_RESERVE			= 10	; energy kept aside when casting non-core skills - enough for one shout
+Global Const $AP_SHOUT_DAMAGE_CONFIDENCE		= 0.9	; safety factor on expected shout damage when predicting a drop below 50%
+Global Const $AP_ENERGY_HEADROOM_FOR_REFUND		= 10	; Auspicious Incantation is not worth casting when this close to max energy
+Global Const $AP_IDLE_SLEEP						= 250	; sleep when no skill can be used
+
+; Damage of "Finish Him!" and "You Move Like a Dwarf!" per Norn rank, and title points needed to reach each rank
+Global Const $AP_NORN_SHOUT_DAMAGE[]			= [44, 51, 58, 66, 73, 80, 80, 80, 80, 80, 80]
+Global Const $AP_NORN_RANK_POINTS[]				= [1000, 2000, 4000, 8000, 16000, 25000, 40000, 65000, 100000, 160000]
+
+; Skill slots detected by SetupAPBuild - -1 when the skill is not on the bar
+Global $BUILD_XA_ASSASSINS_PROMISE				= -1
+Global $BUILD_XA_FINISH_HIM						= -1
+Global $BUILD_XA_YOU_MOVE_LIKE_A_DWARF			= -1
+Global $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT	= -1
+Global $BUILD_XA_ARCANE_ECHO					= -1
+Global $BUILD_XA_AUSPICIOUS_INCANTATION			= -1
+
+
+;~ Set up the Assassin's Promise build: learn the skill slots and set the combat function.
+;~ Overwrites the default combat function on the option maps so all MoveAggro* calls use it.
+;~ Returns True if the build was recognised, False otherwise (default combat function is kept).
+Func SetupAPBuild()
+	$BUILD_XA_ASSASSINS_PROMISE				= -1
+	$BUILD_XA_FINISH_HIM					= -1
+	$BUILD_XA_YOU_MOVE_LIKE_A_DWARF			= -1
+	$BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT	= -1
+	$BUILD_XA_ARCANE_ECHO					= -1
+	$BUILD_XA_AUSPICIOUS_INCANTATION		= -1
+
+	Local $skillbar = GetSkillbar(0)
+	Local $fillerSlots = ''
+	For $i = 1 To 8
+		Local $skillID = DllStructGetData($skillbar, 'SkillID' & $i)
+		Switch $skillID
+			Case $ID_ASSASSINS_PROMISE
+				$BUILD_XA_ASSASSINS_PROMISE = $i
+			Case $ID_FINISH_HIM
+				$BUILD_XA_FINISH_HIM = $i
+			Case $ID_YOU_MOVE_LIKE_A_DWARF
+				$BUILD_XA_YOU_MOVE_LIKE_A_DWARF = $i
+			Case $ID_EBON_VANGUARD_ASSASSIN_SUPPORT
+				$BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT = $i
+			Case $ID_ARCANE_ECHO
+				$BUILD_XA_ARCANE_ECHO = $i
+			Case $ID_AUSPICIOUS_INCANTATION
+				$BUILD_XA_AUSPICIOUS_INCANTATION = $i
+			Case 0
+				; empty slot
+			Case Else
+				$fillerSlots &= ($fillerSlots == '' ? '' : ', ') & $i
+		EndSwitch
+	Next
+
+	If $BUILD_XA_ASSASSINS_PROMISE < 0 Then
+		Warn('Assassin''s Promise is not on the skillbar - keeping the default combat routine')
+		Return False
+	EndIf
+
+	Info('Assassin''s Promise build detected - using the build-aware combat routine')
+	Debug('AP build slots - Promise: ' & $BUILD_XA_ASSASSINS_PROMISE & ', Finish Him: ' & $BUILD_XA_FINISH_HIM _
+		& ', Move Like a Dwarf: ' & $BUILD_XA_YOU_MOVE_LIKE_A_DWARF & ', Assassin Support: ' & $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT _
+		& ', Arcane Echo: ' & $BUILD_XA_ARCANE_ECHO & ', Auspicious Incantation: ' & $BUILD_XA_AUSPICIOUS_INCANTATION _
+		& ', other skills played from left to right: ' & ($fillerSlots == '' ? 'none' : $fillerSlots))
+	If $BUILD_XA_FINISH_HIM < 0 Then Warn('"Finish Him!" is not on the skillbar - Assassin''s Promise build will be weaker')
+	If $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT < 0 Then Warn('Ebon Vanguard Assassin Support is not on the skillbar - Assassin''s Promise build will be weaker')
+	If $BUILD_XA_ARCANE_ECHO > 0 And $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT < 0 Then Warn('Arcane Echo has nothing to copy without Ebon Vanguard Assassin Support - it will not be used')
+
+	$default_move_aggro_kill_options['killMethod']	= APCombat
+	$flag_move_aggro_kill_options['killMethod']		= APCombat
+	$optionsFollower['killMethod']					= APCombat
+	Return True
+EndFunc
+
+
+;~ Combat callback for KillFoesInArea: attacks and uses one skill per iteration according to the Assassin's Promise rules until target is dead.
+Func APCombat($target, $options)
+	Local $abortCondition		= $options['abortCondition'] <> Null ?		$options['abortCondition'] : Null
+
+	; get as close as possible to target foe to have a surprise effect when attacking
+	GetAlmostInRangeOfAgent($target)
+	While $target <> Null And Not GetIsDead($target) And DllStructGetData($target, 'HealthPercent') > 0 And DllStructGetData($target, 'ID') <> 0 And DllStructGetData($target, 'Allegiance') == $ID_ALLEGIANCE_FOE
+		; Always ensure auto-attack is active before using skills - wand and staff hits add up
+		Attack($target)
+		PingSleep(100)
+		If Not CastAssassinsPromiseSkill($target) Then RandomSleep($AP_IDLE_SLEEP)
+		$target = GetCurrentTarget()
+		If IsPlayerDead() Then ExitLoop
+		If $abortCondition <> Null And $abortCondition() Then Return
+	WEnd
+EndFunc
+
+
+;~ Use at most one skill on the target according to the Assassin's Promise rules.
+;~ Returns True if a skill was used, False if nothing could be used this iteration.
+Func CastAssassinsPromiseSkill($target)
+	Local Static $lastTargetID = 0
+	Local Static $finishHimUsed = False
+
+	; Per target state - "Finish Him!" is tracked per target so "You Move Like a Dwarf!" follows it
+	Local $targetID = DllStructGetData($target, 'ID')
+	If $targetID <> $lastTargetID Then
+		$lastTargetID = $targetID
+		$finishHimUsed = False
+	EndIf
+
+	; One snapshot of the skillbar and energy per iteration to limit memory reads
+	Local $skillbar = GetSkillbar()
+	Local $skillTimer = GetSkillTimer()
+	Local $energy = GetEnergy()
+	Local $targetHealth = DllStructGetData($target, 'HealthPercent')
+
+	; Arcane Echo state - its slot shows the copied skill ID while a copy exists
+	Local $echoSlotID = 0, $echoWaitingForSpell = False, $echoCopyReady = False
+	If $BUILD_XA_ARCANE_ECHO > 0 Then
+		$echoSlotID = DllStructGetData($skillbar, 'SkillID' & $BUILD_XA_ARCANE_ECHO)
+		If $echoSlotID == $ID_ARCANE_ECHO Then $echoWaitingForSpell = GetEffect($ID_ARCANE_ECHO) <> Null
+		If $echoSlotID == $ID_EBON_VANGUARD_ASSASSIN_SUPPORT Then $echoCopyReady = IsSkillRecharged($skillbar, $BUILD_XA_ARCANE_ECHO, $skillTimer)
+	EndIf
+	; Any non-spell skill ends Arcane Echo, so shouts wait until the copy has been created and spent
+	Local $shoutsAllowed = Not $echoWaitingForSpell And Not $echoCopyReady
+	Local $auspiciousActive = False
+	If $BUILD_XA_AUSPICIOUS_INCANTATION > 0 Then $auspiciousActive = GetEffect($ID_AUSPICIOUS_INCANTATION) <> Null
+
+	Local $canAssassinSupport = IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $energy)
+	Local $canArcaneEcho = CanCastArcaneEcho($skillbar, $skillTimer, $energy, $echoSlotID, $echoWaitingForSpell, $auspiciousActive)
+
+	; 1. Assassin's Promise once the target is getting close to 50% - the kill then recharges everything and refunds energy
+	If $targetHealth <= $AP_CAST_HEALTH_THRESHOLD And IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_ASSASSINS_PROMISE, $energy) Then
+		; Auspicious Incantation must never be spent on Assassin's Promise, and Arcane Echo should copy Ebon Vanguard Assassin Support
+		; Both are only respected when the spell they wait for can actually be cast - otherwise the kill matters more
+		Local $spellPending = ($auspiciousActive And ($canAssassinSupport Or $canArcaneEcho)) Or ($echoWaitingForSpell And $canAssassinSupport)
+		If Not $spellPending Then Return UseAPSkill($BUILD_XA_ASSASSINS_PROMISE, $target, 'Assassin''s Promise')
+	EndIf
+
+	; 2. "Finish Him!" only below 50% - deep wound, cracked armor and damage
+	If $shoutsAllowed And $targetHealth < $AP_FINISH_HIM_HEALTH_THRESHOLD And IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_FINISH_HIM, $energy) Then
+		If UseAPSkill($BUILD_XA_FINISH_HIM, $target, '"Finish Him!"') Then
+			$finishHimUsed = True
+			Return True
+		EndIf
+	EndIf
+
+	; 3. "You Move Like a Dwarf!" after "Finish Him!", or when it would bring the target below 50% with energy left for "Finish Him!"
+	If $shoutsAllowed And IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_YOU_MOVE_LIKE_A_DWARF, $energy) Then
+		Local $finishHimOnBar = $BUILD_XA_FINISH_HIM > 0
+		Local $finishHimReady = False
+		If $finishHimOnBar Then $finishHimReady = IsSkillRecharged($skillbar, $BUILD_XA_FINISH_HIM, $skillTimer)
+		If $targetHealth < $AP_FINISH_HIM_HEALTH_THRESHOLD Then
+			; "Finish Him!" had priority above - if it was not used here it is either done, recharging or missing
+			If $finishHimUsed Or Not $finishHimReady Then Return UseAPSkill($BUILD_XA_YOU_MOVE_LIKE_A_DWARF, $target, '"You Move Like a Dwarf!"')
+		Else
+			Local $maxHealth = GetAgentMaxHealthEstimate($target)
+			Local $expectedDamage = GetNornShoutDamage() * $AP_SHOUT_DAMAGE_CONFIDENCE
+			Local $wouldDropBelowHalf = ($targetHealth * $maxHealth - $expectedDamage) < ($AP_FINISH_HIM_HEALTH_THRESHOLD * $maxHealth)
+			Local $finishHimCost = $finishHimOnBar ? GetSkillEnergyCost($ID_FINISH_HIM) : 0
+			Local $energyLeftForFinishHim = $energy >= GetSkillEnergyCost($ID_YOU_MOVE_LIKE_A_DWARF) + $finishHimCost
+			If $wouldDropBelowHalf And (Not $finishHimOnBar Or $finishHimReady) And $energyLeftForFinishHim Then Return UseAPSkill($BUILD_XA_YOU_MOVE_LIKE_A_DWARF, $target, '"You Move Like a Dwarf!"')
+		EndIf
+	EndIf
+
+	; 4. Mesmer energy and copy management - only worth starting while the target is still healthy, the spike takes a few seconds
+	If $targetHealth > $AP_CAST_HEALTH_THRESHOLD And Not $echoWaitingForSpell And Not $echoCopyReady Then
+		; Auspicious Incantation refunds more than the cost of the next spell - Arcane Echo is the best candidate, Ebon Vanguard Assassin Support is fine
+		If Not $auspiciousActive And IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_AUSPICIOUS_INCANTATION, $energy) And $energy <= GetMaxEnergy() - $AP_ENERGY_HEADROOM_FOR_REFUND Then
+			Local $energyAfterIncantation = $energy - GetSkillEnergyCost($ID_AUSPICIOUS_INCANTATION)
+			Local $echoAffordable = CanCastArcaneEcho($skillbar, $skillTimer, $energyAfterIncantation, $echoSlotID, $echoWaitingForSpell, True)
+			Local $assassinSupportAffordable = IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $energyAfterIncantation)
+			If $echoAffordable Or $assassinSupportAffordable Then Return UseAPSkill($BUILD_XA_AUSPICIOUS_INCANTATION, Null, 'Auspicious Incantation')
+		EndIf
+		; Arcane Echo only right before Ebon Vanguard Assassin Support
+		If $canArcaneEcho Then Return UseAPSkill($BUILD_XA_ARCANE_ECHO, Null, 'Arcane Echo')
+	EndIf
+
+	; 5. Ebon Vanguard Assassin Support - the original first so Arcane Echo gets its copy, then the copy on the same target for a double spike
+	If $echoWaitingForSpell And $canAssassinSupport Then Return UseAPSkill($BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $target, 'Ebon Vanguard Assassin Support (to be echoed)')
+	If $echoCopyReady And $energy >= GetSkillEnergyCost($ID_EBON_VANGUARD_ASSASSIN_SUPPORT) Then Return UseAPSkill($BUILD_XA_ARCANE_ECHO, $target, 'Ebon Vanguard Assassin Support (echoed copy)')
+	If $canAssassinSupport Then Return UseAPSkill($BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $target, 'Ebon Vanguard Assassin Support')
+
+	; 6. Anything else on the bar, from left to right
+	Return UseAPFillerSkill($skillbar, $skillTimer, $energy, $target)
+EndFunc
+
+
+;~ Arcane Echo is only cast when Ebon Vanguard Assassin Support is recharged and there is energy for Arcane Echo,
+;~ Ebon Vanguard Assassin Support and its echoed copy. With Auspicious Incantation active the refund covers Arcane Echo itself.
+Func CanCastArcaneEcho($skillbar, $skillTimer, $energy, $echoSlotID, $echoWaitingForSpell, $auspiciousActive)
+	If $BUILD_XA_ARCANE_ECHO < 0 Or $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT < 0 Then Return False
+	If $echoSlotID <> $ID_ARCANE_ECHO Or $echoWaitingForSpell Then Return False
+	If Not IsSkillRecharged($skillbar, $BUILD_XA_ARCANE_ECHO, $skillTimer) Then Return False
+	If Not IsSkillRecharged($skillbar, $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $skillTimer) Then Return False
+	Local $echoCost = GetSkillEnergyCost($ID_ARCANE_ECHO)
+	Local $assassinSupportCost = GetSkillEnergyCost($ID_EBON_VANGUARD_ASSASSIN_SUPPORT)
+	Local $energyNeeded = $auspiciousActive ? _Max($echoCost, 2 * $assassinSupportCost) : $echoCost + 2 * $assassinSupportCost
+	Return $energy >= $energyNeeded
+EndFunc
+
+
+;~ Use the next non-core skill that is recharged and affordable, rotating from left to right across calls.
+;~ Keeps $AP_FILLER_ENERGY_RESERVE energy aside so a shout stays available for the spike.
+Func UseAPFillerSkill($skillbar, $skillTimer, $energy, $target)
+	Local Static $nextSlot = 1
+	For $offset = 0 To 7
+		Local $slot = Mod($nextSlot - 1 + $offset, 8) + 1
+		If IsAPCoreSlot($slot) Then ContinueLoop
+		Local $skillID = DllStructGetData($skillbar, 'SkillID' & $slot)
+		If $skillID == 0 Then ContinueLoop
+		If Not IsSkillRecharged($skillbar, $slot, $skillTimer) Then ContinueLoop
+		If $energy < GetSkillEnergyCost($skillID) + $AP_FILLER_ENERGY_RESERVE Then ContinueLoop
+		$nextSlot = Mod($slot, 8) + 1
+		Return UseAPSkill($slot, $target)
+	Next
+	Return False
+EndFunc
+
+
+;~ Return True if the slot holds one of the skills handled by the Assassin's Promise rules
+Func IsAPCoreSlot($slot)
+	Switch $slot
+		Case $BUILD_XA_ASSASSINS_PROMISE, $BUILD_XA_FINISH_HIM, $BUILD_XA_YOU_MOVE_LIKE_A_DWARF, $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $BUILD_XA_ARCANE_ECHO, $BUILD_XA_AUSPICIOUS_INCANTATION
+			Return True
+	EndSwitch
+	Return False
+EndFunc
+
+
+;~ Return True if the slot exists, is recharged and its skill is affordable with the given energy
+Func IsAPSlotUsable($skillbar, $skillTimer, $slot, $energy)
+	If $slot < 1 Then Return False
+	If Not IsSkillRecharged($skillbar, $slot, $skillTimer) Then Return False
+	Return $energy >= GetSkillEnergyCost(DllStructGetData($skillbar, 'SkillID' & $slot))
+EndFunc
+
+
+;~ Use a skill and report whether it went off. UseSkillEx can time out on instant skills (shouts) before the
+;~ recharge is visible, so the recharge state is checked again after a short delay.
+Func UseAPSkill($slot, $target = Null, $name = '')
+	If $name <> '' Then Debug('AP build - ' & $name)
+	Local $used = UseSkillEx($slot, $target)
+	If Not $used Then
+		PingSleep(100)
+		$used = Not IsRecharged($slot)
+	EndIf
+	Return $used
+EndFunc
+
+
+;~ Energy cost of a skill - the game stores 15 and 25 energy as special values
+Func GetSkillEnergyCost($skillID)
+	Local Static $costs[]
+	If $skillID == 0 Then Return 0
+	If MapExists($costs, $skillID) Then Return $costs[$skillID]
+	Local $cost = DllStructGetData(GetSkillByID($skillID), 'EnergyCost')
+	Switch $cost
+		Case 11
+			$cost = 15
+		Case 12
+			$cost = 25
+	EndSwitch
+	$costs[$skillID] = $cost
+	Return $cost
+EndFunc
+
+
+;~ Maximum energy of the player
+Func GetMaxEnergy()
+	Return DllStructGetData(GetMyAgent(), 'MaxEnergy')
+EndFunc
+
+
+;~ Maximum health of an agent - foes do not always expose it, so fall back to the usual creature health for their level
+Func GetAgentMaxHealthEstimate($agent)
+	Local $maxHealth = DllStructGetData($agent, 'MaxHealth')
+	If $maxHealth > 0 Then Return $maxHealth
+	Return 100 + 20 * DllStructGetData($agent, 'Level')
+EndFunc
+
+
+;~ Norn title rank, derived from title points
+Func GetNornRank()
+	Local $points = GetNornTitle()
+	Local $rank = 0
+	For $threshold In $AP_NORN_RANK_POINTS
+		If $points >= $threshold Then $rank += 1
+	Next
+	Return $rank
+EndFunc
+
+
+;~ Damage dealt by "Finish Him!" and "You Move Like a Dwarf!" at the current Norn rank
+Func GetNornShoutDamage()
+	Return $AP_NORN_SHOUT_DAMAGE[GetNornRank()]
+EndFunc


### PR DESCRIPTION
## Summary

Vanquish, dungeon and title bots play the player build from skill 1 to 8. The Assassin's Promise builds suggested in the farm descriptions ([Me/A](https://gwpvx.fandom.com/wiki/Build:Me/A_Assassin%27s_Promise), [N/A](https://gwpvx.fandom.com/wiki/Build:N/A_Assassin%27s_Promise_Death_Magic), [E/A](https://gwpvx.fandom.com/wiki/Build:E/A_Assassin%27s_Promise)) are far stronger when the elite and the two Norn shouts are timed, so this adds a build-aware combat routine, auto-detected whenever Assassin's Promise is on the skillbar, following the `Build_PW_Heroic-Refrain.au3` pattern.

- New `lib/Build_XA_Assassins-Promise.au3`: `SetupAPBuild` learns the slots of Assassin's Promise, "Finish Him!", "You Move Like a Dwarf!", Ebon Vanguard Assassin Support, Arcane Echo and Auspicious Incantation, then installs `APCombat` as `killMethod` on the default, flag and Follower option maps.
- One skill per iteration, by priority:
  1. Assassin's Promise once the target is at or below 60% health
  2. "Finish Him!" under 50% (no effect above)
  3. "You Move Like a Dwarf!" after "Finish Him!" on that target, or when "Finish Him!" cannot be used, or when its damage (real Norn rank) would push the target under 50% while keeping energy for "Finish Him!"
  4. Mesmer: Auspicious Incantation only right before Arcane Echo or Assassin Support (never on Assassin's Promise), Arcane Echo only when Assassin Support can follow immediately, echoed copy used at once on the same target
  5. Ebon Vanguard Assassin Support
  6. Any other skill from left to right, keeping 10 energy for a shout
- Shouts are held while Arcane Echo waits for a spell or holds an unused copy, since any non-spell skill ends it.
- Energy costs come from the skill struct (`GetSkillEnergyCost` decodes the 15/25 special values); foe max health falls back to a level-based estimate when the game does not expose it.
- `SetupPlayerBuildOverrides` now detects builds for any primary profession and resets the kill method first. New option **Smart Assassin's Promise casting** (Team tab, `run.smart_assassins_promise`, default on, missing key in old configs also on) falls back to 1-to-8 casting.
- Farm description text, default configuration and README updated. Tunables (threshold, energy reserve, damage confidence) sit at the top of the library.

## Test plan

- [x] Au3Check on BotsHub.au3: no new errors or warnings versus the master baseline
- [ ] Me/A bar in a vanquish: follow the `AP build -` debug lines and check the sequence Auspicious Incantation, Arcane Echo, Assassin Support twice, Promise, "Finish Him!", "You Move Like a Dwarf!"
- [ ] Untick *Smart Assassin's Promise casting* and confirm 1-to-8 casting is back
- [ ] N/A and E/A bars: core rules apply, remaining skills play left to right

Follow-ups: Elementalist rules (attunement upkeep, Glyph of Lesser Energy before expensive spells) and Necromancer rules (Putrid Bile, corpse-dependent Putrid Explosion, minions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
