### PR TITLE
feat: Inventory tab organised by item with one decision per leaf, bigger window

### DIFF
--- a/BotsHub.au3
+++ b/BotsHub.au3
@@ -148,6 +148,7 @@ $run_options_cache['run.use_consets'] = False
 $run_options_cache['run.use_scrolls'] = False
 $run_options_cache['run.sort_items'] = False
 $run_options_cache['run.farm_materials_mid_run'] = False
+$run_options_cache['run.salvage_into_components'] = False
 $run_options_cache['run.bags_count'] = 5
 $run_options_cache['run.donate_faction_points'] = True
 $run_options_cache['run.buy_faction_scrolls'] = False
@@ -438,6 +439,7 @@ Func ReadConfigFromJson($jsonString)
 	$run_options_cache['run.hard_mode'] = _JSON_Get($jsonObject, 'run.hard_mode')
 	$run_options_cache['run.share_memory'] = _JSON_Get($jsonObject, 'run.share_memory')
 	$run_options_cache['run.farm_materials_mid_run'] = _JSON_Get($jsonObject, 'run.farm_materials_mid_run')
+	$run_options_cache['run.salvage_into_components'] = _JSON_Get($jsonObject, 'run.salvage_into_components')
 	$run_options_cache['run.consume_consumables'] = _JSON_Get($jsonObject, 'run.consume_consumables')
 	$run_options_cache['run.use_consets'] = _JSON_Get($jsonObject, 'run.use_consets')
 	$run_options_cache['run.use_scrolls'] = _JSON_Get($jsonObject, 'run.use_scrolls')
@@ -492,6 +494,7 @@ Func WriteConfigToJson()
 	_JSON_addChangeDelete($jsonObject, 'run.hard_mode', $run_options_cache['run.hard_mode'])
 	_JSON_addChangeDelete($jsonObject, 'run.share_memory', $run_options_cache['run.share_memory'])
 	_JSON_addChangeDelete($jsonObject, 'run.farm_materials_mid_run', $run_options_cache['run.farm_materials_mid_run'])
+	_JSON_addChangeDelete($jsonObject, 'run.salvage_into_components', $run_options_cache['run.salvage_into_components'])
 	_JSON_addChangeDelete($jsonObject, 'run.consume_consumables', $run_options_cache['run.consume_consumables'])
 	_JSON_addChangeDelete($jsonObject, 'run.use_consets', $run_options_cache['run.use_consets'])
 	_JSON_addChangeDelete($jsonObject, 'run.use_scrolls', $run_options_cache['run.use_scrolls'])

--- a/BotsHub.au3
+++ b/BotsHub.au3
@@ -49,6 +49,7 @@ Opt('MustDeclareVars', True)
 #include 'lib/Utils-Shared_Memory.au3'
 #include 'lib/Utils-Storage.au3'
 #include 'lib/Build_PW_Heroic-Refrain.au3'
+#include 'lib/Build_XA_Assassins-Promise.au3'
 
 #include 'src/farms/CoF.au3'
 #include 'src/farms/Corsairs.au3'
@@ -154,6 +155,7 @@ $run_options_cache['run.buy_faction_resources'] = False
 $run_options_cache['run.collect_data'] = False
 $run_options_cache['run.go_offline'] = False
 $run_options_cache['run.flash_whisper'] = False
+$run_options_cache['run.smart_assassins_promise'] = True
 $run_options_cache['team.automatic_team_setup'] = False
 ; Overrides on $run_options_cache for frequent usage
 Global $district_name = 'Default'
@@ -444,6 +446,9 @@ Func ReadConfigFromJson($jsonString)
 	$run_options_cache['run.collect_data'] = _JSON_Get($jsonObject, 'run.collect_data')
 	$run_options_cache['run.go_offline'] = _JSON_Get($jsonObject, 'run.go_offline')
 	$run_options_cache['run.flash_whisper'] = _JSON_Get($jsonObject, 'run.flash_whisper')
+	; Older configuration files do not have this key - smart casting is enabled by default
+	Local $smartAssassinsPromise = _JSON_Get($jsonObject, 'run.smart_assassins_promise')
+	$run_options_cache['run.smart_assassins_promise'] = @error ? True : $smartAssassinsPromise
 	$run_options_cache['run.donate_faction_points'] = _JSON_Get($jsonObject, 'run.donate_faction_points')
 	$run_options_cache['run.buy_faction_resources'] = _JSON_Get($jsonObject, 'run.buy_faction_resources')
 	$run_options_cache['run.buy_faction_scrolls'] = _JSON_Get($jsonObject, 'run.buy_faction_scrolls')
@@ -494,6 +499,7 @@ Func WriteConfigToJson()
 	_JSON_addChangeDelete($jsonObject, 'run.collect_data', $run_options_cache['run.collect_data'])
 	_JSON_addChangeDelete($jsonObject, 'run.go_offline', $run_options_cache['run.go_offline'])
 	_JSON_addChangeDelete($jsonObject, 'run.flash_whisper', $run_options_cache['run.flash_whisper'])
+	_JSON_addChangeDelete($jsonObject, 'run.smart_assassins_promise', $run_options_cache['run.smart_assassins_promise'])
 	_JSON_addChangeDelete($jsonObject, 'run.donate_faction_points', $run_options_cache['run.donate_faction_points'])
 	_JSON_addChangeDelete($jsonObject, 'run.buy_faction_resources', $run_options_cache['run.buy_faction_resources'])
 	_JSON_addChangeDelete($jsonObject, 'run.buy_faction_scrolls', $run_options_cache['run.buy_faction_scrolls'])
@@ -694,11 +700,22 @@ EndFunc
 
 ;~ Auto-detect player build and wire up specialized combat/maintenance routines
 Func SetupPlayerBuildOverrides()
+	; Start from the default combat routine so a previous build override does not linger
+	$default_move_aggro_kill_options['killMethod']	= UseSkillSequentially
+	$flag_move_aggro_kill_options['killMethod']		= UseSkillSequentially
+	$optionsFollower['killMethod']					= UseSkillSequentially
+
 	; For build detection, we iterate over skills and key skills + profession will give use which build must be used
 	Local $profession = GetHeroProfession(0)
 	Local $skillbar = GetSkillbar(0)
 	For $i = 1 To 8
 		Local $skillID = DllStructGetData($skillbar, 'SkillID' & $i)
+		; Builds recognised whatever the primary profession
+		If $skillID == $ID_ASSASSINS_PROMISE Then
+			If $run_options_cache['run.smart_assassins_promise'] Then Return SetupAPBuild()
+			Info('Assassin''s Promise is on the skillbar but smart casting is disabled - skills will be used from 1 to 8')
+			Return
+		EndIf
 		If $profession == $ID_PARAGON Then
 			If $skillID == $ID_HEROIC_REFRAIN Then Return SetupHRBuild()
 			;If $skillID == ... Then Return ...

--- a/BotsHub.au3
+++ b/BotsHub.au3
@@ -46,6 +46,7 @@ Opt('MustDeclareVars', True)
 #include 'lib/Utils-Console.au3'
 #include 'lib/Utils-Debugger.au3'
 #include 'lib/Utils-Items_Modstructs.au3'
+#include 'lib/Utils-Loot_Configuration.au3'
 #include 'lib/Utils-Shared_Memory.au3'
 #include 'lib/Utils-Storage.au3'
 #include 'lib/Build_PW_Heroic-Refrain.au3'
@@ -140,7 +141,6 @@ Global $slave_heartbeat = 0
 Global $farm_map[]
 Global $gui_enabled
 
-Global $inventory_management_cache[]
 Global $run_options_cache[]
 $run_options_cache['run.district'] = 'Default'
 $run_options_cache['run.consume_consumables'] = True
@@ -148,7 +148,6 @@ $run_options_cache['run.use_consets'] = False
 $run_options_cache['run.use_scrolls'] = False
 $run_options_cache['run.sort_items'] = False
 $run_options_cache['run.farm_materials_mid_run'] = False
-$run_options_cache['run.salvage_into_components'] = False
 $run_options_cache['run.bags_count'] = 5
 $run_options_cache['run.donate_faction_points'] = True
 $run_options_cache['run.buy_faction_scrolls'] = False
@@ -390,8 +389,7 @@ Func LoadLootConfiguration($filePath)
 	; Removing .json
 	$loot_configuration = StringTrimRight($loot_configuration, 5)
 	Local $jsonLootOptions = LoadLootOptions($filePath)
-	FillInventoryCacheFromJSON($jsonLootOptions, '')
-	BuildInventoryDerivedFlags()
+	LoadLootDecisionsFromJson($jsonLootOptions)
 	RefreshValuableListsFromCache()
 	Info('Loaded loot configuration at ' & $filePath)
 EndFunc
@@ -439,7 +437,6 @@ Func ReadConfigFromJson($jsonString)
 	$run_options_cache['run.hard_mode'] = _JSON_Get($jsonObject, 'run.hard_mode')
 	$run_options_cache['run.share_memory'] = _JSON_Get($jsonObject, 'run.share_memory')
 	$run_options_cache['run.farm_materials_mid_run'] = _JSON_Get($jsonObject, 'run.farm_materials_mid_run')
-	$run_options_cache['run.salvage_into_components'] = _JSON_Get($jsonObject, 'run.salvage_into_components')
 	$run_options_cache['run.consume_consumables'] = _JSON_Get($jsonObject, 'run.consume_consumables')
 	$run_options_cache['run.use_consets'] = _JSON_Get($jsonObject, 'run.use_consets')
 	$run_options_cache['run.use_scrolls'] = _JSON_Get($jsonObject, 'run.use_scrolls')
@@ -494,7 +491,6 @@ Func WriteConfigToJson()
 	_JSON_addChangeDelete($jsonObject, 'run.hard_mode', $run_options_cache['run.hard_mode'])
 	_JSON_addChangeDelete($jsonObject, 'run.share_memory', $run_options_cache['run.share_memory'])
 	_JSON_addChangeDelete($jsonObject, 'run.farm_materials_mid_run', $run_options_cache['run.farm_materials_mid_run'])
-	_JSON_addChangeDelete($jsonObject, 'run.salvage_into_components', $run_options_cache['run.salvage_into_components'])
 	_JSON_addChangeDelete($jsonObject, 'run.consume_consumables', $run_options_cache['run.consume_consumables'])
 	_JSON_addChangeDelete($jsonObject, 'run.use_consets', $run_options_cache['run.use_consets'])
 	_JSON_addChangeDelete($jsonObject, 'run.use_scrolls', $run_options_cache['run.use_scrolls'])
@@ -764,93 +760,6 @@ EndFunc
 
 
 ;~ Fill the inventory cache with additional derived data
-Func BuildInventoryDerivedFlags()
-	; -------- Pickup --------
-	Local $pickupSomething = IsAnyChecked('Pick up items')
-	$inventory_management_cache['@pickup.something'] = $pickupSomething
-	$inventory_management_cache['@pickup.nothing'] = Not $pickupSomething
-	Local $pickupSomeWeapons = IsAnyChecked('Pick up items.Weapons and offhands')
-	$inventory_management_cache['@pickup.weapons.something'] = $pickupSomeWeapons
-	$inventory_management_cache['@pickup.weapons.nothing'] = Not $pickupSomeWeapons
-
-	; -------- Identify --------
-	Local $identifySomething = IsAnyChecked('Identify items')
-	$inventory_management_cache['@identify.something'] = $identifySomething
-	$inventory_management_cache['@identify.nothing'] = Not $identifySomething
-
-	; -------- Salvage --------
-	Local $salvageSomething = IsAnyChecked('Salvage items')
-	$inventory_management_cache['@salvage.something'] = $salvageSomething
-	$inventory_management_cache['@salvage.nothing'] = Not $salvageSomething
-	Local $salvageSomeWeapons = IsAnyChecked('Salvage items.Weapons and offhands')
-	$inventory_management_cache['@salvage.weapons.something'] = $salvageSomeWeapons
-	$inventory_management_cache['@salvage.weapons.nothing'] = Not $salvageSomeWeapons
-	Local $salvageSomeSalvageables = IsAnyChecked('Salvage items.Armor salvageables')
-	$inventory_management_cache['@salvage.salvageables.something'] = $salvageSomeSalvageables
-	$inventory_management_cache['@salvage.salvageables.nothing'] = Not $salvageSomeSalvageables
-	Local $salvageSomeTrophies = IsAnyChecked('Salvage items.Trophies')
-	$inventory_management_cache['@salvage.trophies.something'] = $salvageSomeTrophies
-	$inventory_management_cache['@salvage.trophies.nothing'] = Not $salvageSomeTrophies
-	Local $salvageSomeMaterials = IsAnyChecked('Salvage items.Rare Materials')
-	$inventory_management_cache['@salvage.materials.something'] = $salvageSomeMaterials
-	$inventory_management_cache['@salvage.materials.nothing'] = Not $salvageSomeMaterials
-
-	; -------- Sell --------
-	Local $sellSomething = IsAnyChecked('Sell items')
-	$inventory_management_cache['@sell.something'] = $sellSomething
-	$inventory_management_cache['@sell.nothing'] = Not $sellSomething
-	Local $sellSomeWeapons = IsAnyChecked('Sell items.Weapons and offhands')
-	$inventory_management_cache['@sell.weapons.something'] = $sellSomeWeapons
-	$inventory_management_cache['@sell.weapons.nothing'] = Not $sellSomeWeapons
-
-	Local $sellSomeBasicMaterials = IsAnyChecked('Sell items.Basic Materials')
-	$inventory_management_cache['@sell.materials.basic.something'] = $sellSomeBasicMaterials
-	$inventory_management_cache['@sell.materials.basic.nothing'] = Not $sellSomeBasicMaterials
-	Local $sellSomeRareMaterials = IsAnyChecked('Sell items.Rare Materials')
-	$inventory_management_cache['@sell.materials.rare.something'] = $sellSomeRareMaterials
-	$inventory_management_cache['@sell.materials.rare.nothing'] = Not $sellSomeRareMaterials
-	Local $sellSomeMaterials = $sellSomeBasicMaterials Or $sellSomeRareMaterials
-	$inventory_management_cache['@sell.materials.something'] = $sellSomeMaterials
-	$inventory_management_cache['@sell.materials.nothing'] = Not $sellSomeMaterials
-
-	; -------- Buy --------
-	Local $buySomething = IsAnyChecked('Buy items')
-	$inventory_management_cache['@buy.something'] = $buySomething
-	$inventory_management_cache['@buy.nothing'] = Not $buySomething
-
-	Local $buySomeBasicMaterials = IsAnyChecked('Buy items.Basic Materials')
-	$inventory_management_cache['@buy.materials.basic.something'] = $buySomeBasicMaterials
-	$inventory_management_cache['@buy.materials.basic.nothing'] = Not $buySomeBasicMaterials
-	Local $buySomeRareMaterials = IsAnyChecked('Buy items.Rare Materials')
-	$inventory_management_cache['@buy.materials.rare.something'] = $buySomeRareMaterials
-	$inventory_management_cache['@buy.materials.rare.nothing'] = Not $buySomeRareMaterials
-	Local $buySomeMaterials = $buySomeBasicMaterials Or $buySomeRareMaterials
-	$inventory_management_cache['@buy.materials.something'] = $buySomeMaterials
-	$inventory_management_cache['@buy.materials.nothing'] = Not $buySomeMaterials
-
-	; -------- Store --------
-	Local $storeSomething = IsAnyChecked('Store items')
-	$inventory_management_cache['@store.something'] = $storeSomething
-	$inventory_management_cache['@store.nothing'] = Not $storeSomething
-	Local $storeSomeWeapons = IsAnyChecked('Store items.Weapons and offhands')
-	$inventory_management_cache['@store.weapons.something'] = $storeSomeWeapons
-	$inventory_management_cache['@store.weapons.nothing'] = Not $storeSomeWeapons
-EndFunc
-
-
-;~ Return if any option at provided path or lower in the tree is checked
-Func IsAnyChecked($path)
-	Local $pathLength = StringLen($path) + 1
-	For $key In MapKeys($inventory_management_cache)
-		If Not $inventory_management_cache[$key] Then ContinueLoop
-		If $key == $path Then Return True
-		If StringLen($key) <= $pathLength Then ContinueLoop
-		If StringLeft($key, $pathLength) == ($path & '.') Then Return True
-	Next
-	Return False
-EndFunc
-
-
 ;~ Return checked leaf options under provided path
 Func GetAllChecked($map, $path, $minDepth = -1, $maxDepth = -1)
 	Local $checkedElements[0]

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The **Inventory** tab lists item families (weapons by type, rarity, requirement 
 
 A change on a group applies to every item below it, and each row shows its decision in brackets (`[mixed]` for groups whose items differ). The tree checkboxes tick items that are picked up, mods that are salvaged and materials that are bought.
 
-Weapons have a few rules on top of their leaf: equipped and customized items are never touched, the *Low req max stats* rule replaces the leaf of non white weapons with a requirement under 9 and max stats, ultra rare skins and perfect old school weapons are stored instead of being salvaged or sold, and rare skins with max stats have their own leaf under each requirement.
+Weapons have a few rules on top of their leaf: equipped and customized items are never touched, the *Low req max stats* rule replaces the leaf of non white weapons with a requirement under 9 and max stats, ultra rare skins and perfect old school weapons are stored instead of being salvaged or sold, and rare skins with max stats have their own leaf under each requirement. The skins counted as rare or ultra rare are listed per weapon type in [doc/rare-skins.md](doc/rare-skins.md).
 
 The **Mods** section says, for each weapon mod, inscription, rune and insignia, whether it is salvaged out of items that are salvaged or sold (with an expert kit) and whether the salvaged mod is stored or sold. Stored items keep their mods.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To use it:
 ## Features
 - Unified interface shared by all bots 🖥️
 - Shared inventory, loot, farm, and title tracking 🎯
-- Configurable item handling (pickup, identify, salvage, salvage into components, sell, buy, store) 📦
+- One decision per item: ignore, identify, then keep, salvage, sell or store, plus a mods section for what to salvage out of unwanted items 📦
 - Farm UI with build, equipment, and contextual information 🛡️
 - Build-aware combat when a known player build is detected (Heroic Refrain, Assassin's Promise) 🧠
 - Modular, plug-and-play bot system 🔌
@@ -116,6 +116,24 @@ Vanquish, dungeon and title bots play whatever build the character carries. With
 
 ---
 
+## Inventory configuration
+
+The **Inventory** tab lists item families (weapons by type, rarity, requirement and skin, armor salvageables, trophies, materials, consumables, tomes, scrolls, dyes...) as a tree. Select an item or a group and set its decision in the panel on the right:
+
+- **Ignore**: the item is never picked up and never touched in the bags. It blocks the other options.
+- **Identify**: the item is identified before anything else happens to it.
+- **Keep in the bags**, **Salvage**, **Sell** or **Store in the Xunlai storage**: exactly one of them.
+
+A change on a group applies to every item below it, and each row shows its decision in brackets (`[mixed]` for groups whose items differ). The tree checkboxes tick items that are picked up, mods that are salvaged and materials that are bought.
+
+Weapons have a few rules on top of their leaf: equipped and customized items are never touched, the *Low req max stats* rule replaces the leaf of non white weapons with a requirement under 9 and max stats, ultra rare skins and perfect old school weapons are stored instead of being salvaged or sold, and rare skins with max stats have their own leaf under each requirement.
+
+The **Mods** section says, for each weapon mod, inscription, rune and insignia, whether it is salvaged out of items that are salvaged or sold (with an expert kit) and whether the salvaged mod is stored or sold. Stored items keep their mods.
+
+Loot files saved by previous versions (one tree per action) are migrated when loaded: an item is ignored when it was not picked up, salvage wins over sell which wins over store, and identification follows the former rarity setting. Save the file again to keep it in the new format.
+
+---
+
 ## Repository Structure
 - `BotsHub.au3`: Main launcher script that acts as a hub for all bots.
 - `/lib/`: Common shared utility files and GWA2 interfacing logic.
@@ -174,8 +192,7 @@ Check your system locale. Set it to English and that should fix the problem.
 <details>
 <summary><strong>Q: How can I change what items the bot sells?</strong></summary>
 
-Most options are configurable in the interface.  
-Advanced customization requires manual file edits ✏️
+Use the **Inventory** tab: select the item or the group and pick its decision (ignore, identify, keep, salvage, sell or store), then click *Apply changes* and *Save* to keep it 📦
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To use it:
 - Shared inventory, loot, farm, and title tracking 🎯
 - Configurable item handling (pickup, identify, salvage, sell, buy, store) 📦
 - Farm UI with build, equipment, and contextual information 🛡️
+- Build-aware combat when a known player build is detected (Heroic Refrain, Assassin's Promise) 🧠
 - Modular, plug-and-play bot system 🔌
 
 ---
@@ -79,6 +80,8 @@ To use it:
 | Dalada Uplands				| Vanguard								|
 | Secret Lair of the Snowmen	| Deldrimor								|
 | Pre-Searing					| Legendary Defender of Ascalon (LDOA)	|
+
+Vanquish, dungeon and title bots play whatever build the character carries. With an Assassin's Promise build (Me/A, N/A, E/A) the bot uses a dedicated casting routine: Assassin's Promise once the target is close to 50% health, "Finish Him!" under 50%, "You Move Like a Dwarf!" to finish, Ebon Vanguard Assassin Support otherwise, and the mesmer's Arcane Echo and Auspicious Incantation only where they pay off. Untick *Smart Assassin's Promise casting* in the Team tab to fall back to casting skills from 1 to 8.
 
 ### Dungeons / Elite Zones
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To use it:
 ## Features
 - Unified interface shared by all bots 🖥️
 - Shared inventory, loot, farm, and title tracking 🎯
-- Configurable item handling (pickup, identify, salvage, sell, buy, store) 📦
+- Configurable item handling (pickup, identify, salvage, salvage into components, sell, buy, store) 📦
 - Farm UI with build, equipment, and contextual information 🛡️
 - Build-aware combat when a known player build is detected (Heroic Refrain, Assassin's Promise) 🧠
 - Modular, plug-and-play bot system 🔌

--- a/conf/farm/Default Farm Configuration.json
+++ b/conf/farm/Default Farm Configuration.json
@@ -9,6 +9,7 @@
 		"hard_mode": true,
 		"share_memory": false,
 		"farm_materials_mid_run": false,
+		"salvage_into_components": false,
 		"consume_consumables": true,
 		"use_consets": false,
 		"use_scrolls": false,

--- a/conf/farm/Default Farm Configuration.json
+++ b/conf/farm/Default Farm Configuration.json
@@ -22,7 +22,8 @@
 		"district": "Default",
 		"disable_rendering": false,
 		"go_offline": false,
-		"flash_whisper": false
+		"flash_whisper": false,
+		"smart_assassins_promise": true
 	},
 	"team": {
 		"automatic_team_setup": false,

--- a/conf/farm/Default Farm Configuration.json
+++ b/conf/farm/Default Farm Configuration.json
@@ -9,7 +9,6 @@
 		"hard_mode": true,
 		"share_memory": false,
 		"farm_materials_mid_run": false,
-		"salvage_into_components": false,
 		"consume_consumables": true,
 		"use_consets": false,
 		"use_scrolls": false,

--- a/conf/loot/Default Loot Configuration.json
+++ b/conf/loot/Default Loot Configuration.json
@@ -1,3319 +1,3501 @@
 ﻿{
-	"Pick up items": {
-		"Gold": true,
-		"Consumables": true,
-		"Alcohols": {
-			"Minor (1pt)": true,
-			"Major (3pt)": true,
-			"Superior (50pt)": true
-		},
-		"Party": {
-			"Minor (1-2pt)": true,
-			"Major (3-7pt)": true,
-			"Superior (25-50pt)": true
-		},
-		"Sweets": {
-			"Minor (1-2pt)": true,
-			"Major (3pt)": true,
-			"Superior (50pt)": true
-		},
-		"PCons": {
-			"Drake Kabob": true,
-			"Bowl of Skalefin Soup": true,
-			"Pahnai Salad": true,
-			"Birthday Cupcake": true,
-			"Golden Egg": true,
-			"Candy Apple": true,
-			"Candy Corn": true,
-			"Slice of Pumpkin Pie": true,
-			"Blue Rock Candy": true,
-			"Green Rock Candy": true,
-			"Red Rock Candy": true,
-			"War Supplies": true,
-			"Lunar Fortune (Pig)": true,
-			"Lunar Fortune (Rat)": true,
-			"Lunar Fortune (Ox)": true,
-			"Lunar Fortune (Tiger)": true,
-			"Lunar Fortune (Rabbit)": true,
-			"Lunar Fortune (Dragon)": true,
-			"Lunar Fortune (Snake)": true,
-			"Lunar Fortune (Horse)": true,
-			"Lunar Fortune (Sheep)": true,
-			"Lunar Fortune (Monkey)": true,
-			"Lunar Fortune (Rooster)": true,
-			"Lunar Fortune (Dog)": true
-		},
-		"Morale": {
-			"Peppermint Candy Cane": true,
-			"Refined Jelly": true,
-			"Elixir of Valor": true,
-			"Wintergreen Candy Cane": true,
-			"Rainbow Candy Cane": true,
-			"Four Leaf Clover": true,
-			"Honeycomb": true,
-			"Pumpkin Cookie": true,
-			"Oath of Purity": true,
-			"Seal of the Dragon Empire": true,
-			"Shining Blade Ration": true
-		},
-		"Special drops": {
-			"Candy Cane Shard": true,
-			"Victory Token": true,
-			"Wintersday Gift": true,
-			"Wayfarer Mark": true,
-			"Lunar Token": true,
-			"Lunar Tokens": true,
-			"Trick-or-Treat Bag": true,
-			"Flame of Balthazar": true,
-			"Golden Flame of Balthazar": true,
-			"Celestial Sigil": true,
-			"Stalkers Rations": true,
-			"Birds Eye Compass": true
-		},
+	"Items": {
+		"Gold": "store",
 		"Weapons and offhands": {
-			"Low Req Max Stats": true,
-			"White": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+			"Low req max stats": "identify+store",
+			"Axe": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
 				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
+				"Green": "keep"
 			},
-			"Blue": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+			"Sword": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
 				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
+				"Green": "keep"
 			},
-			"Purple": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+			"Dagger": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": true,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
 				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": true,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": true,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
+				"Green": "keep"
 			},
-			"Gold": {
-				"Axe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+			"Hammer": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Bow": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Dagger": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Focus": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
 				},
-				"Hammer": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Scythe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Shield": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Spear": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Staff": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Sword": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Wand": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				}
+				"Green": "keep"
 			},
-			"Green": {
-				"Axe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+			"Scythe": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Bow": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Dagger": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Focus": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
 				},
-				"Hammer": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Green": "keep"
+			},
+			"Spear": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Scythe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Shield": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Spear": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
 				},
-				"Staff": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Green": "keep"
+			},
+			"Bow": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Sword": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
 				},
-				"Wand": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				}
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
+				},
+				"Green": "keep"
+			},
+			"Wand": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
+				},
+				"Green": "keep"
+			},
+			"Staff": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
+				},
+				"Green": "keep"
+			},
+			"Focus": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
+				},
+				"Green": "keep"
+			},
+			"Shield": {
+				"White": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Blue": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Purple": {
+					"Req 0": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 1": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 2": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 3": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 4": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 5": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 6": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 7": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 10": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 11": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 12": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					},
+					"Req 13": {
+						"Rare skins": "ignore",
+						"Other skins": "ignore"
+					}
+				},
+				"Gold": {
+					"Req 0": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 1": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 2": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 3": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 4": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 5": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 6": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 7": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 8": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 9": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 10": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 11": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 12": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					},
+					"Req 13": {
+						"Rare skins": "identify+sell",
+						"Other skins": "identify+sell"
+					}
+				},
+				"Green": "keep"
 			}
 		},
 		"Armor salvageables": {
-			"White": false,
-			"Blue": true,
-			"Purple": true,
-			"Gold": true
-		},
-		"Basic Materials": {
-			"Bone": true,
-			"Bolt of Cloth": true,
-			"Chitin Fragment": true,
-			"Feather": true,
-			"Granite Slab": true,
-			"Iron Ingot": true,
-			"Pile of Glittering Dust": true,
-			"Plant Fiber": true,
-			"Scale": true,
-			"Tanned Hide Square": true,
-			"Wood Plank": true
-		},
-		"Rare Materials": {
-			"Fur Square": true,
-			"Bolt of Linen": true,
-			"Bolt of Damask": true,
-			"Bolt of Silk": true,
-			"Glob of Ectoplasm": true,
-			"Steel Ingot": true,
-			"Deldrimor Steel Ingot": true,
-			"Monstrous Claw": true,
-			"Monstrous Eye": true,
-			"Monstrous Fang": true,
-			"Ruby": true,
-			"Sapphire": true,
-			"Diamond": true,
-			"Onyx Gemstone": true,
-			"Lump of Charcoal": true,
-			"Obsidian Shard": true,
-			"Tempered Glass Vial": true,
-			"Leather Square": true,
-			"Elonian Leather Square": true,
-			"Vial of Ink": true,
-			"Roll of Parchment": true,
-			"Roll of Vellum": true,
-			"Spiritwood Plank": true,
-			"Amber Chunk": true,
-			"Jadeite Shard": true
+			"White": "ignore",
+			"Blue": "identify+sell",
+			"Purple": "identify+sell",
+			"Gold": "identify+sell"
 		},
 		"Trophies": {
-			"Margonite Gemstone": true,
-			"Stygian Gemstone": true,
-			"Titan Gemstone": true,
-			"Torment Gemstone": true,
-			"Diessa Chalice": true,
-			"Golden Rin Relic": true,
-			"Superb Charr Carving": true,
-			"Chunk of Drake Flesh": true,
-			"Skale Fin": true,
-			"Iboga Petal": true,
-			"Destroyer Core": true,
-			"Glacial Stone": true,
-			"Saurian Bone": true,
-			"Jade Bracelet": true,
-			"Dark Remains": true,
-			"Demonic Remains": true,
-			"Other trophies": true
+			"Margonite Gemstone": "store",
+			"Stygian Gemstone": "store",
+			"Titan Gemstone": "store",
+			"Torment Gemstone": "store",
+			"Diessa Chalice": "store",
+			"Golden Rin Relic": "store",
+			"Superb Charr Carving": "store",
+			"Chunk of Drake Flesh": "store",
+			"Skale Fin": "store",
+			"Iboga Petal": "store",
+			"Destroyer Core": "store",
+			"Glacial Stone": "salvage",
+			"Saurian Bone": "salvage",
+			"Jade Bracelet": "store",
+			"Dark Remains": "salvage",
+			"Demonic Remains": "salvage",
+			"Common material trophies": "salvage",
+			"Nicholas trophies": "keep",
+			"Rare material trophies": "keep",
+			"Other trophies": "sell"
+		},
+		"Basic Materials": {
+			"Bone": "store",
+			"Bolt of Cloth": "store",
+			"Chitin Fragment": "store",
+			"Feather": "store",
+			"Granite Slab": "store",
+			"Iron Ingot": "store",
+			"Pile of Glittering Dust": "store",
+			"Plant Fiber": "store",
+			"Scale": "store",
+			"Tanned Hide Square": "store",
+			"Wood Plank": "store"
+		},
+		"Rare Materials": {
+			"Fur Square": "store",
+			"Bolt of Linen": "store",
+			"Bolt of Damask": "store",
+			"Bolt of Silk": "store",
+			"Glob of Ectoplasm": "store",
+			"Steel Ingot": "salvage",
+			"Deldrimor Steel Ingot": "store",
+			"Monstrous Claw": "store",
+			"Monstrous Eye": "store",
+			"Monstrous Fang": "store",
+			"Ruby": "store",
+			"Sapphire": "store",
+			"Diamond": "store",
+			"Onyx Gemstone": "store",
+			"Lump of Charcoal": "store",
+			"Obsidian Shard": "store",
+			"Tempered Glass Vial": "store",
+			"Leather Square": "store",
+			"Elonian Leather Square": "store",
+			"Vial of Ink": "store",
+			"Roll of Parchment": "store",
+			"Roll of Vellum": "store",
+			"Spiritwood Plank": "store",
+			"Amber Chunk": "store",
+			"Jadeite Shard": "store"
+		},
+		"Consumables": "store",
+		"Alcohols": {
+			"Minor (1pt)": "store",
+			"Major (3pt)": "store",
+			"Superior (50pt)": "store"
+		},
+		"Party": {
+			"Minor (1-2pt)": "store",
+			"Major (3-7pt)": "store",
+			"Superior (25-50pt)": "store"
+		},
+		"Sweets": {
+			"Minor (1-2pt)": "store",
+			"Major (3pt)": "store",
+			"Superior (50pt)": "store"
+		},
+		"PCons": {
+			"Drake Kabob": "store",
+			"Bowl of Skalefin Soup": "store",
+			"Pahnai Salad": "store",
+			"Birthday Cupcake": "keep",
+			"Golden Egg": "store",
+			"Candy Apple": "store",
+			"Candy Corn": "store",
+			"Slice of Pumpkin Pie": "keep",
+			"Blue Rock Candy": "store",
+			"Green Rock Candy": "store",
+			"Red Rock Candy": "store",
+			"War Supplies": "store",
+			"Lunar Fortune (Pig)": "store",
+			"Lunar Fortune (Rat)": "store",
+			"Lunar Fortune (Ox)": "store",
+			"Lunar Fortune (Tiger)": "store",
+			"Lunar Fortune (Rabbit)": "store",
+			"Lunar Fortune (Dragon)": "store",
+			"Lunar Fortune (Snake)": "store",
+			"Lunar Fortune (Horse)": "store",
+			"Lunar Fortune (Sheep)": "store",
+			"Lunar Fortune (Monkey)": "store",
+			"Lunar Fortune (Rooster)": "store",
+			"Lunar Fortune (Dog)": "store"
+		},
+		"Morale": {
+			"Peppermint Candy Cane": "store",
+			"Refined Jelly": "store",
+			"Elixir of Valor": "store",
+			"Wintergreen Candy Cane": "store",
+			"Rainbow Candy Cane": "store",
+			"Four Leaf Clover": "store",
+			"Honeycomb": "keep",
+			"Pumpkin Cookie": "store",
+			"Oath of Purity": "store",
+			"Seal of the Dragon Empire": "store",
+			"Shining Blade Ration": "store"
+		},
+		"Special drops": {
+			"Candy Cane Shard": "store",
+			"Victory Token": "store",
+			"Wintersday Gift": "store",
+			"Wayfarer Mark": "store",
+			"Lunar Token": "store",
+			"Lunar Tokens": "store",
+			"Trick-or-Treat Bag": "store",
+			"Flame of Balthazar": "store",
+			"Golden Flame of Balthazar": "store",
+			"Celestial Sigil": "store",
+			"Stalkers Rations": "store",
+			"Birds Eye Compass": "store"
+		},
+		"Consets": {
+			"Heroes Trifecta": "keep",
+			"Essence of Celerity": "keep",
+			"Armor of Salvation": "keep",
+			"Grail of Might": "keep",
+			"Scroll of Resurrection": "keep",
+			"Empowering Feasts": "keep"
+		},
+		"Summoning stones": {
+			"Cracked Ascalonian War Horn": "keep",
+			"Igneous Summoning Stone": "keep",
+			"Legionnaire Summoning Crystal": "keep",
+			"Ghastly Summon": "keep",
+			"Mystical Summon": "keep",
+			"Tengu Summon": "keep",
+			"Imperial Guard Summon": "keep",
+			"Automaton Summon": "keep",
+			"Chitinous Summon": "keep",
+			"Amber Summon": "keep",
+			"Arctic Summon": "keep",
+			"Demonic Summon": "keep",
+			"Gelatinous Summon": "keep",
+			"Fossilized Summon": "keep",
+			"Jadeite Summon": "keep",
+			"Mischievous Summon": "keep",
+			"Frosty Summon": "keep",
+			"Zaishen Summon": "keep",
+			"Celestial Summon": "keep",
+			"Shining Blade Summon": "keep",
+			"Mysterious Summon": "keep",
+			"Merchant Summon": "keep"
 		},
 		"Tomes": {
 			"Normal": {
-				"Warrior Tome": true,
-				"Ranger Tome": true,
-				"Monk Tome": true,
-				"Necromancer Tome": true,
-				"Mesmer Tome": true,
-				"Elementalist Tome": true,
-				"Assassin Tome": true,
-				"Ritualist Tome": true,
-				"Paragon Tome": true,
-				"Dervish Tome": true
+				"Warrior Tome": "store",
+				"Ranger Tome": "store",
+				"Monk Tome": "store",
+				"Necromancer Tome": "store",
+				"Mesmer Tome": "store",
+				"Elementalist Tome": "store",
+				"Assassin Tome": "store",
+				"Ritualist Tome": "store",
+				"Paragon Tome": "store",
+				"Dervish Tome": "store"
 			},
 			"Elite": {
-				"Elite Warrior Tome": true,
-				"Elite Ranger Tome": true,
-				"Elite Monk Tome": true,
-				"Elite Necromancer Tome": true,
-				"Elite Mesmer Tome": true,
-				"Elite Elementalist Tome": true,
-				"Elite Assassin Tome": true,
-				"Elite Ritualist Tome": true,
-				"Elite Paragon Tome": true,
-				"Elite Dervish Tome": true
+				"Elite Warrior Tome": "store",
+				"Elite Ranger Tome": "store",
+				"Elite Monk Tome": "store",
+				"Elite Necromancer Tome": "store",
+				"Elite Mesmer Tome": "store",
+				"Elite Elementalist Tome": "store",
+				"Elite Assassin Tome": "store",
+				"Elite Ritualist Tome": "store",
+				"Elite Paragon Tome": "store",
+				"Elite Dervish Tome": "store"
 			}
 		},
 		"Scrolls": {
-			"Blue": true,
+			"Blue": "sell",
 			"Gold": {
-				"Passage Scroll to the Fissure of Woe": true,
-				"Passage Scroll to the Underworld": true,
-				"Passage Scroll to the Deep": true,
-				"Passage Scroll to Urgozs Warren": true,
-				"Other gold scrolls": true
+				"Passage Scroll to the Fissure of Woe": "store",
+				"Passage Scroll to the Underworld": "store",
+				"Passage Scroll to the Deep": "store",
+				"Passage Scroll to Urgozs Warren": "store",
+				"Other gold scrolls": "sell"
 			}
 		},
 		"Dyes": {
-			"Black": true,
-			"Blue": false,
-			"Brown": false,
-			"Gray": false,
-			"Green": false,
-			"Orange": false,
-			"Pink": false,
-			"Purple": false,
-			"Red": false,
-			"Silver": false,
-			"White": true,
-			"Yellow": false
+			"Black": "store",
+			"Blue": "ignore",
+			"Brown": "ignore",
+			"Gray": "ignore",
+			"Green": "ignore",
+			"Orange": "ignore",
+			"Pink": "ignore",
+			"Purple": "ignore",
+			"Red": "ignore",
+			"Silver": "ignore",
+			"White": "store",
+			"Yellow": "ignore"
 		},
+		"Keys": "sell",
+		"Lockpicks": "keep",
+		"Miniatures": "keep",
 		"Quest items": {
-			"Map pieces": false
+			"Map pieces": "ignore"
 		},
-		"Lockpicks": true,
-		"Keys": true,
-		"Miniatures": true
+		"Other items": {
+			"Stackables": "keep",
+			"Unknown items": "ignore"
+		}
 	},
-	"Identify items": {
-		"White": false,
-		"Blue": true,
-		"Purple": true,
-		"Gold": true
-	},
-	"Keep components": {
+	"Mods": {
 		"Armor upgrades": {
 			"All": {
 				"Insignias": {
-					"Survivor": false,
-					"Radiant": false,
-					"Stalwart": false,
-					"Brawlers": false,
-					"Blessed": false,
-					"Heralds": false,
-					"Sentrys": false
+					"Survivor": "ignore",
+					"Radiant": "ignore",
+					"Stalwart": "ignore",
+					"Brawlers": "ignore",
+					"Blessed": "ignore",
+					"Heralds": "ignore",
+					"Sentrys": "ignore"
 				},
 				"Runes": {
-					"Minor Vigor": true,
-					"Vitae": false,
-					"Attunement": false,
-					"Major Vigor": true,
-					"Recovery": false,
-					"Restoration": false,
-					"Clarity": false,
-					"Purity": false,
-					"Superior Vigor": true
+					"Minor Vigor": "salvage+store",
+					"Vitae": "ignore",
+					"Attunement": "ignore",
+					"Major Vigor": "salvage+store",
+					"Recovery": "ignore",
+					"Restoration": "ignore",
+					"Clarity": "ignore",
+					"Purity": "ignore",
+					"Superior Vigor": "salvage+store"
 				}
 			},
 			"Assassin": {
 				"Insignias": {
-					"Vanguards": false,
-					"Infiltrators": false,
-					"Saboteurs": false,
-					"Nightstalkers": false
+					"Vanguards": "ignore",
+					"Infiltrators": "ignore",
+					"Saboteurs": "ignore",
+					"Nightstalkers": "ignore"
 				},
 				"Runes": {
-					"Minor Critical Strikes": true,
-					"Minor Dagger Mastery": false,
-					"Minor Deadly Arts": false,
-					"Minor Shadow Arts": false,
-					"Major Critical Strikes": false,
-					"Major Dagger Mastery": false,
-					"Major Deadly Arts": false,
-					"Major Shadow Arts": false,
-					"Superior Critical Strikes": false,
-					"Superior Dagger Mastery": false,
-					"Superior Deadly Arts": false,
-					"Superior Shadow Arts": false
+					"Minor Critical Strikes": "salvage+store",
+					"Minor Dagger Mastery": "ignore",
+					"Minor Deadly Arts": "ignore",
+					"Minor Shadow Arts": "ignore",
+					"Major Critical Strikes": "ignore",
+					"Major Dagger Mastery": "ignore",
+					"Major Deadly Arts": "ignore",
+					"Major Shadow Arts": "ignore",
+					"Superior Critical Strikes": "ignore",
+					"Superior Dagger Mastery": "ignore",
+					"Superior Deadly Arts": "ignore",
+					"Superior Shadow Arts": "ignore"
 				}
 			},
 			"Dervish": {
 				"Insignias": {
-					"Windwalker": true,
-					"Forsaken": false
+					"Windwalker": "salvage+store",
+					"Forsaken": "ignore"
 				},
 				"Runes": {
-					"Minor Earth Prayers": true,
-					"Minor Mysticism": false,
-					"Minor Scythe Mastery": true,
-					"Minor Wind Prayers": false,
-					"Major Earth Prayers": false,
-					"Major Mysticism": false,
-					"Major Scythe Mastery": false,
-					"Major Wind Prayers": false,
-					"Superior Earth Prayers": false,
-					"Superior Mysticism": false,
-					"Superior Scythe Mastery": false,
-					"Superior Wind Prayers": false
+					"Minor Earth Prayers": "salvage+store",
+					"Minor Mysticism": "ignore",
+					"Minor Scythe Mastery": "salvage+store",
+					"Minor Wind Prayers": "ignore",
+					"Major Earth Prayers": "ignore",
+					"Major Mysticism": "ignore",
+					"Major Scythe Mastery": "ignore",
+					"Major Wind Prayers": "ignore",
+					"Superior Earth Prayers": "ignore",
+					"Superior Mysticism": "ignore",
+					"Superior Scythe Mastery": "ignore",
+					"Superior Wind Prayers": "ignore"
 				}
 			},
 			"Elementalist": {
 				"Insignias": {
-					"Hydromancer": false,
-					"Geomancer": false,
-					"Pyromancer": false,
-					"Aeromancer": false,
-					"Prismatic": false
+					"Hydromancer": "ignore",
+					"Geomancer": "ignore",
+					"Pyromancer": "ignore",
+					"Aeromancer": "ignore",
+					"Prismatic": "ignore"
 				},
 				"Runes": {
-					"Minor Air Magic": false,
-					"Minor Earth Magic": false,
-					"Minor Energy Storage": false,
-					"Minor Water Magic": false,
-					"Minor Fire Magic": false,
-					"Major Air Magic": false,
-					"Major Earth Magic": false,
-					"Major Energy Storage": false,
-					"Major Fire Magic": false,
-					"Major Water Magic": false,
-					"Superior Air Magic": false,
-					"Superior Earth Magic": false,
-					"Superior Energy Storage": false,
-					"Superior Fire Magic": false,
-					"Superior Water Magic": false
+					"Minor Air Magic": "ignore",
+					"Minor Earth Magic": "ignore",
+					"Minor Energy Storage": "ignore",
+					"Minor Water Magic": "ignore",
+					"Minor Fire Magic": "ignore",
+					"Major Air Magic": "ignore",
+					"Major Earth Magic": "ignore",
+					"Major Energy Storage": "ignore",
+					"Major Fire Magic": "ignore",
+					"Major Water Magic": "ignore",
+					"Superior Air Magic": "ignore",
+					"Superior Earth Magic": "ignore",
+					"Superior Energy Storage": "ignore",
+					"Superior Fire Magic": "ignore",
+					"Superior Water Magic": "ignore"
 				}
 			},
 			"Mesmer": {
 				"Insignias": {
-					"Virtuosos": false,
-					"Artificers": false,
-					"Prodigys": true
+					"Virtuosos": "ignore",
+					"Artificers": "ignore",
+					"Prodigys": "salvage+store"
 				},
 				"Runes": {
-					"Minor Domination Magic": false,
-					"Minor Fast Casting": false,
-					"Minor Illusion Magic": false,
-					"Minor Inspiration Magic": true,
-					"Major Domination Magic": false,
-					"Major Fast Casting": false,
-					"Major Illusion Magic": false,
-					"Major Inspiration Magic": false,
-					"Superior Domination Magic": false,
-					"Superior Fast Casting": false,
-					"Superior Illusion Magic": false,
-					"Superior Inspiration Magic": false
+					"Minor Domination Magic": "ignore",
+					"Minor Fast Casting": "ignore",
+					"Minor Illusion Magic": "ignore",
+					"Minor Inspiration Magic": "salvage+store",
+					"Major Domination Magic": "ignore",
+					"Major Fast Casting": "ignore",
+					"Major Illusion Magic": "ignore",
+					"Major Inspiration Magic": "ignore",
+					"Superior Domination Magic": "ignore",
+					"Superior Fast Casting": "ignore",
+					"Superior Illusion Magic": "ignore",
+					"Superior Inspiration Magic": "ignore"
 				}
 			},
 			"Monk": {
 				"Insignias": {
-					"Wanderers": false,
-					"Disciples": false,
-					"Anchorites": true
+					"Wanderers": "ignore",
+					"Disciples": "ignore",
+					"Anchorites": "salvage+store"
 				},
 				"Runes": {
-					"Minor Divine Favor": false,
-					"Minor Healing Prayers": false,
-					"Minor Protection Prayers": false,
-					"Minor Smiting Prayers": false,
-					"Major Healing Prayers": false,
-					"Major Protection Prayers": false,
-					"Major Smiting Prayers": false,
-					"Major Divine Favor": false,
-					"Superior Divine Favor": false,
-					"Superior Healing Prayers": false,
-					"Superior Protection Prayers": false,
-					"Superior Smiting Prayers": false
+					"Minor Divine Favor": "ignore",
+					"Minor Healing Prayers": "ignore",
+					"Minor Protection Prayers": "ignore",
+					"Minor Smiting Prayers": "ignore",
+					"Major Healing Prayers": "ignore",
+					"Major Protection Prayers": "ignore",
+					"Major Smiting Prayers": "ignore",
+					"Major Divine Favor": "ignore",
+					"Superior Divine Favor": "ignore",
+					"Superior Healing Prayers": "ignore",
+					"Superior Protection Prayers": "ignore",
+					"Superior Smiting Prayers": "ignore"
 				}
 			},
 			"Necromancer": {
 				"Insignias": {
-					"Bloodstained": false,
-					"Tormentors": true,
-					"Bonelace": false,
-					"Minion Masters": true,
-					"Blighters": false,
-					"Undertakers": false
+					"Bloodstained": "ignore",
+					"Tormentors": "salvage+store",
+					"Bonelace": "ignore",
+					"Minion Masters": "salvage+store",
+					"Blighters": "ignore",
+					"Undertakers": "ignore"
 				},
 				"Runes": {
-					"Minor Blood Magic": true,
-					"Minor Curses": false,
-					"Minor Death Magic": false,
-					"Minor Soul Reaping": false,
-					"Major Blood Magic": false,
-					"Major Curses": false,
-					"Major Death Magic": false,
-					"Major Soul Reaping": false,
-					"Superior Blood Magic": false,
-					"Superior Curses": false,
-					"Superior Death Magic": false,
-					"Superior Soul Reaping": false
+					"Minor Blood Magic": "salvage+store",
+					"Minor Curses": "ignore",
+					"Minor Death Magic": "ignore",
+					"Minor Soul Reaping": "ignore",
+					"Major Blood Magic": "ignore",
+					"Major Curses": "ignore",
+					"Major Death Magic": "ignore",
+					"Major Soul Reaping": "ignore",
+					"Superior Blood Magic": "ignore",
+					"Superior Curses": "ignore",
+					"Superior Death Magic": "ignore",
+					"Superior Soul Reaping": "ignore"
 				}
 			},
 			"Paragon": {
 				"Insignias": {
-					"Centurions": true
+					"Centurions": "salvage+store"
 				},
 				"Runes": {
-					"Minor Command": false,
-					"Minor Leadership": true,
-					"Minor Motivation": false,
-					"Minor Spear Mastery": false,
-					"Major Command": false,
-					"Major Leadership": false,
-					"Major Motivation": false,
-					"Major Spear Mastery": false,
-					"Superior Command": false,
-					"Superior Leadership": false,
-					"Superior Motivation": false,
-					"Superior Spear Mastery": false
+					"Minor Command": "ignore",
+					"Minor Leadership": "salvage+store",
+					"Minor Motivation": "ignore",
+					"Minor Spear Mastery": "ignore",
+					"Major Command": "ignore",
+					"Major Leadership": "ignore",
+					"Major Motivation": "ignore",
+					"Major Spear Mastery": "ignore",
+					"Superior Command": "ignore",
+					"Superior Leadership": "ignore",
+					"Superior Motivation": "ignore",
+					"Superior Spear Mastery": "ignore"
 				}
 			},
 			"Ranger": {
 				"Insignias": {
-					"Frostbound": false,
-					"Pyrebound": false,
-					"Stormbound": false,
-					"Scouts": false,
-					"Earthbound": false,
-					"Beastmasters": true
+					"Frostbound": "ignore",
+					"Pyrebound": "ignore",
+					"Stormbound": "ignore",
+					"Scouts": "ignore",
+					"Earthbound": "ignore",
+					"Beastmasters": "salvage+store"
 				},
 				"Runes": {
-					"Minor Beast Mastery": false,
-					"Minor Expertise": false,
-					"Minor Marksmanship": false,
-					"Minor Wilderness Survival": false,
-					"Major Beast Mastery": false,
-					"Major Expertise": false,
-					"Major Marksmanship": false,
-					"Major Wilderness Survival": false,
-					"Superior Beast Mastery": false,
-					"Superior Expertise": false,
-					"Superior Marksmanship": false,
-					"Superior Wilderness Survival": false
+					"Minor Beast Mastery": "ignore",
+					"Minor Expertise": "ignore",
+					"Minor Marksmanship": "ignore",
+					"Minor Wilderness Survival": "ignore",
+					"Major Beast Mastery": "ignore",
+					"Major Expertise": "ignore",
+					"Major Marksmanship": "ignore",
+					"Major Wilderness Survival": "ignore",
+					"Superior Beast Mastery": "ignore",
+					"Superior Expertise": "ignore",
+					"Superior Marksmanship": "ignore",
+					"Superior Wilderness Survival": "ignore"
 				}
 			},
 			"Ritualist": {
 				"Insignias": {
-					"Shamans": true,
-					"Ghost Forge": false,
-					"Mystics": false
+					"Shamans": "salvage+store",
+					"Ghost Forge": "ignore",
+					"Mystics": "ignore"
 				},
 				"Runes": {
-					"Minor Channeling Magic": true,
-					"Minor Communing": true,
-					"Minor Restoration Magic": true,
-					"Minor Spawning Power": false,
-					"Major Channeling Magic": false,
-					"Major Communing": false,
-					"Major Restoration Magic": false,
-					"Major Spawning Power": false,
-					"Superior Channeling Magic": false,
-					"Superior Communing": false,
-					"Superior Restoration Magic": false,
-					"Superior Spawning Power": true
+					"Minor Channeling Magic": "salvage+store",
+					"Minor Communing": "salvage+store",
+					"Minor Restoration Magic": "salvage+store",
+					"Minor Spawning Power": "ignore",
+					"Major Channeling Magic": "ignore",
+					"Major Communing": "ignore",
+					"Major Restoration Magic": "ignore",
+					"Major Spawning Power": "ignore",
+					"Superior Channeling Magic": "ignore",
+					"Superior Communing": "ignore",
+					"Superior Restoration Magic": "ignore",
+					"Superior Spawning Power": "salvage+store"
 				}
 			},
 			"Warrior": {
 				"Insignias": {
-					"Knights": false,
-					"Lieutenants": false,
-					"Stonefist": false,
-					"Dreadnought": false,
-					"Sentinels": false
+					"Knights": "ignore",
+					"Lieutenants": "ignore",
+					"Stonefist": "ignore",
+					"Dreadnought": "ignore",
+					"Sentinels": "ignore"
 				},
 				"Runes": {
-					"Minor Absorption": false,
-					"Minor Axe Mastery": false,
-					"Minor Hammer Mastery": false,
-					"Minor Strength": false,
-					"Minor Swordsmanship": true,
-					"Minor Tactics": false,
-					"Major Absorption": false,
-					"Major Axe Mastery": false,
-					"Major Hammer Mastery": false,
-					"Major Strength": false,
-					"Major Swordsmanship": false,
-					"Major Tactics": false,
-					"Superior Axe Mastery": false,
-					"Superior Hammer Mastery": false,
-					"Superior Strength": false,
-					"Superior Swordsmanship": false,
-					"Superior Tactics": false,
-					"Superior Absorption": false
+					"Minor Absorption": "ignore",
+					"Minor Axe Mastery": "ignore",
+					"Minor Hammer Mastery": "ignore",
+					"Minor Strength": "ignore",
+					"Minor Swordsmanship": "salvage+store",
+					"Minor Tactics": "ignore",
+					"Major Absorption": "ignore",
+					"Major Axe Mastery": "ignore",
+					"Major Hammer Mastery": "ignore",
+					"Major Strength": "ignore",
+					"Major Swordsmanship": "ignore",
+					"Major Tactics": "ignore",
+					"Superior Axe Mastery": "ignore",
+					"Superior Hammer Mastery": "ignore",
+					"Superior Strength": "ignore",
+					"Superior Swordsmanship": "ignore",
+					"Superior Tactics": "ignore",
+					"Superior Absorption": "ignore"
 				}
 			}
 		},
 		"Inscriptions": {
-			"Measure for measure (Highly salvageable)": false,
-			"Show me the money (Improved sale value)": false,
+			"Measure for measure (Highly salvageable)": "ignore",
+			"Show me the money (Improved sale value)": "ignore",
 			"Weapon": {
-				"Strength and honor (Damage +15% while Health is above 50%)": false,
-				"Guided by fate (Damage +15% while Enchanted)": false,
-				"Dance with death (Damage +15% while in a Stance)": false,
-				"Too much information (Damage +15% vs Hexed foes)": false,
-				"To the pain (Damage +15% Armor -10 while attacking)": false,
-				"Brawn over brain (Damage +15% Energy -5)": false,
-				"Vengeance is mine (Damage +20% while Health is below 50%)": false,
-				"Dont fear the reaper (Damage +20% while Hexed)": false,
-				"Dont think twice (Halves casting time of spells)": false,
+				"Strength and honor (Damage +15% while Health is above 50%)": "ignore",
+				"Guided by fate (Damage +15% while Enchanted)": "ignore",
+				"Dance with death (Damage +15% while in a Stance)": "ignore",
+				"Too much information (Damage +15% vs Hexed foes)": "ignore",
+				"To the pain (Damage +15% Armor -10 while attacking)": "ignore",
+				"Brawn over brain (Damage +15% Energy -5)": "ignore",
+				"Vengeance is mine (Damage +20% while Health is below 50%)": "ignore",
+				"Dont fear the reaper (Damage +20% while Hexed)": "ignore",
+				"Dont think twice (Halves casting time of spells)": "ignore",
 				"Martial": {
-					"I have the power (Energy +5)": false,
-					"Let the memory live again (Halves skill recharge of spells)": false
+					"I have the power (Energy +5)": "ignore",
+					"Let the memory live again (Halves skill recharge of spells)": "ignore"
 				},
 				"Spellcasting": {
-					"Hale and hearty (Energy +5 while Health is above 50%)": false,
-					"Have faith (Energy +5 while Enchanted)": false,
-					"Dont call it a come back (Energy +7 while Health is below 50%)": false,
-					"I am sorrow (Energy +7 while Hexed)": false,
-					"Seize the day (Energy +15 Energy regeneration -1)": false,
-					"Aptitude not attitude (Halves casting time of spells of item's attribute)": true
+					"Hale and hearty (Energy +5 while Health is above 50%)": "ignore",
+					"Have faith (Energy +5 while Enchanted)": "ignore",
+					"Dont call it a come back (Energy +7 while Health is below 50%)": "ignore",
+					"I am sorrow (Energy +7 while Hexed)": "ignore",
+					"Seize the day (Energy +15 Energy regeneration -1)": "ignore",
+					"Aptitude not attitude (Halves casting time of spells of item's attribute)": "salvage+store"
 				}
 			},
 			"Offhand": {
 				"Focus": {
-					"Forget me not (Halves skill recharge of spells of item's attribute)": true,
-					"Serenity now (Halves skill recharge of spells)": false,
-					"Hail to the king (Armor +5 while Health is above 50%)": true,
-					"Faith is my shield (Armor +5 while Enchanted)": false,
-					"Might makes right (Armor +5 while attacking)": false,
-					"Knowing is half the battle (Armor +5 while casting)": false,
-					"Man for all seasons (Armor +5 vs Elemental damage)": false,
-					"Survival of the fittest (Armor +5 vs Physical damage)": false,
-					"Ignorance is bliss (Armor +5 Energy -5)": false,
-					"Life is pain (Armor +5 Health -20)": false,
-					"Down but not out (Armor +10 while Health is below 50%)": false,
-					"Be just and fear not (Armor +10 while hexed)": false,
-					"Live for today (Energy +15 Energy regeneration -1)": false
+					"Forget me not (Halves skill recharge of spells of item's attribute)": "salvage+store",
+					"Serenity now (Halves skill recharge of spells)": "ignore",
+					"Hail to the king (Armor +5 while Health is above 50%)": "salvage+store",
+					"Faith is my shield (Armor +5 while Enchanted)": "ignore",
+					"Might makes right (Armor +5 while attacking)": "ignore",
+					"Knowing is half the battle (Armor +5 while casting)": "ignore",
+					"Man for all seasons (Armor +5 vs Elemental damage)": "ignore",
+					"Survival of the fittest (Armor +5 vs Physical damage)": "ignore",
+					"Ignorance is bliss (Armor +5 Energy -5)": "ignore",
+					"Life is pain (Armor +5 Health -20)": "ignore",
+					"Down but not out (Armor +10 while Health is below 50%)": "ignore",
+					"Be just and fear not (Armor +10 while hexed)": "ignore",
+					"Live for today (Energy +15 Energy regeneration -1)": "ignore"
 				},
-				"Master of my domain (Item's attribute +1)": false,
-				"Not the face (Armor +10 vs Blunt damage)": false,
-				"Leaf on the wind (Armor +10 vs Cold damage)": false,
-				"Like a rolling stone (Armor +10 vs Earth damage)": false,
-				"Sleep now in the fire (Armor +10 vs Fire damage)": false,
-				"Riders on the storm (Armor +10 vs Lightning damage)": false,
-				"Through thick and thin (Armor +10 vs Piercing damage)": false,
-				"The riddle of steel (Armor +10 vs Slashing damage)": false,
-				"Sheltered by faith (Received physical damage -2 while Enchanted)": false,
-				"Run for your life (Received physical damage -2 while in a Stance)": false,
-				"Nothing to fear (Received physical damage -3 while Hexed)": false,
-				"Luck of the draw (Received physical damage -5 - Chance 20%)": false,
-				"Fear cuts deeper (Reduces Bleeding duration on you by 20%)": false,
-				"I can see clearly now (Reduces Blind duration on you by 20%)": false,
-				"Swift as the wind (Reduces Crippled duration on you by 20%)": false,
-				"Soundness of mind (Reduces Dazed duration on you by 20%)": false,
-				"Strength of body (Reduces Deep Wound duration on you by 20%)": false,
-				"Cast out the unclean (Reduces Disease duration on you by 20%)": false,
-				"Pure of heart (Reduces Poison duration on you by 20%)": false,
-				"Only the strong survive (Reduces Weakness duration on you by 20%)": false
+				"Master of my domain (Item's attribute +1)": "ignore",
+				"Not the face (Armor +10 vs Blunt damage)": "ignore",
+				"Leaf on the wind (Armor +10 vs Cold damage)": "ignore",
+				"Like a rolling stone (Armor +10 vs Earth damage)": "ignore",
+				"Sleep now in the fire (Armor +10 vs Fire damage)": "ignore",
+				"Riders on the storm (Armor +10 vs Lightning damage)": "ignore",
+				"Through thick and thin (Armor +10 vs Piercing damage)": "ignore",
+				"The riddle of steel (Armor +10 vs Slashing damage)": "ignore",
+				"Sheltered by faith (Received physical damage -2 while Enchanted)": "ignore",
+				"Run for your life (Received physical damage -2 while in a Stance)": "ignore",
+				"Nothing to fear (Received physical damage -3 while Hexed)": "ignore",
+				"Luck of the draw (Received physical damage -5 - Chance 20%)": "ignore",
+				"Fear cuts deeper (Reduces Bleeding duration on you by 20%)": "ignore",
+				"I can see clearly now (Reduces Blind duration on you by 20%)": "ignore",
+				"Swift as the wind (Reduces Crippled duration on you by 20%)": "ignore",
+				"Soundness of mind (Reduces Dazed duration on you by 20%)": "ignore",
+				"Strength of body (Reduces Deep Wound duration on you by 20%)": "ignore",
+				"Cast out the unclean (Reduces Disease duration on you by 20%)": "ignore",
+				"Pure of heart (Reduces Poison duration on you by 20%)": "ignore",
+				"Only the strong survive (Reduces Weakness duration on you by 20%)": "ignore"
 			}
 		},
-		"Mods": {
+		"Weapon mods": {
 			"Axe": {
 				"Prefix - Haft": {
-					"Ebon (Earth damage)": false,
-					"Fiery (Fire damage)": false,
-					"Icy (Cold damage)": false,
-					"Shocking (Lightning damage)": false,
-					"Barbed (Lengthens Bleeding duration on foes by 33%)": false,
-					"Cruel (Lengthens Deep Wound duration on foes by 33%)": false,
-					"Crippling (Lengthens Crippled duration on foes by 33%)": false,
-					"Heavy (Lengthens Weakness duration on foes by 33%)": false,
-					"Poisonous (Lengthens Poison duration on foes by 33%)": false,
-					"Furious (Double Adrenaline on hit - Chance 10%)": false,
-					"Sundering (Armor penetration +20% - Chance 20%)": false,
-					"Vampiric 3 (Life Draining 3 Health regeneration -1)": false,
-					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": false
+					"Ebon (Earth damage)": "ignore",
+					"Fiery (Fire damage)": "ignore",
+					"Icy (Cold damage)": "ignore",
+					"Shocking (Lightning damage)": "ignore",
+					"Barbed (Lengthens Bleeding duration on foes by 33%)": "ignore",
+					"Cruel (Lengthens Deep Wound duration on foes by 33%)": "ignore",
+					"Crippling (Lengthens Crippled duration on foes by 33%)": "ignore",
+					"Heavy (Lengthens Weakness duration on foes by 33%)": "ignore",
+					"Poisonous (Lengthens Poison duration on foes by 33%)": "ignore",
+					"Furious (Double Adrenaline on hit - Chance 10%)": "ignore",
+					"Sundering (Armor penetration +20% - Chance 20%)": "ignore",
+					"Vampiric 3 (Life Draining 3 Health regeneration -1)": "ignore",
+					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": "ignore"
 				},
 				"Suffix - Grip": {
-					"of Fortitude (Health +30)": false,
-					"Of Defense (Armor +5)": false,
-					"Of Shelter (Armor +7 vs physical damage)": false,
-					"Of Warding (Armor +7 vs elemental damage)": false,
-					"Of Enchanting (Enchantments last 20% longer)": false,
-					"Of The Warrior": false,
-					"Of The Ranger": false,
-					"Of The Necromancer": false,
-					"Of The Mesmer": false,
-					"Of The Elementalist": false,
-					"Of The Monk": false,
-					"Of The Ritualist": false,
-					"Of The Assassin": false,
-					"Of The Paragon": false,
-					"Of The Dervish": false,
-					"Of Deathbane": false,
-					"Of Charrslaying": true,
-					"Of Trollslaying": true,
-					"Of Pruning": true,
-					"Of Skeleton Slaying": true,
-					"Of Giant Slaying": true,
-					"Of Dwarf Slaying": true,
-					"Of Tengu Slaying": true,
-					"Of Demon Slaying": true,
-					"Of Ogre Slaying": true,
-					"Of Dragon Slaying": true,
-					"Of Axe Mastery (Item's attribute +1 - 20% chance while using skills)": false
+					"of Fortitude (Health +30)": "ignore",
+					"Of Defense (Armor +5)": "ignore",
+					"Of Shelter (Armor +7 vs physical damage)": "ignore",
+					"Of Warding (Armor +7 vs elemental damage)": "ignore",
+					"Of Enchanting (Enchantments last 20% longer)": "ignore",
+					"Of The Warrior": "ignore",
+					"Of The Ranger": "ignore",
+					"Of The Necromancer": "ignore",
+					"Of The Mesmer": "ignore",
+					"Of The Elementalist": "ignore",
+					"Of The Monk": "ignore",
+					"Of The Ritualist": "ignore",
+					"Of The Assassin": "ignore",
+					"Of The Paragon": "ignore",
+					"Of The Dervish": "ignore",
+					"Of Deathbane": "ignore",
+					"Of Charrslaying": "salvage+store",
+					"Of Trollslaying": "salvage+store",
+					"Of Pruning": "salvage+store",
+					"Of Skeleton Slaying": "salvage+store",
+					"Of Giant Slaying": "salvage+store",
+					"Of Dwarf Slaying": "salvage+store",
+					"Of Tengu Slaying": "salvage+store",
+					"Of Demon Slaying": "salvage+store",
+					"Of Ogre Slaying": "salvage+store",
+					"Of Dragon Slaying": "salvage+store",
+					"Of Axe Mastery (Item's attribute +1 - 20% chance while using skills)": "ignore"
 				}
 			},
 			"Bow": {
 				"Prefix - String": {
-					"Ebon (Earth damage)": false,
-					"Fiery (Fire damage)": false,
-					"Icy (Cold damage)": false,
-					"Shocking (Lightning damage)": false,
-					"Barbed (Lengthens Bleeding duration on foes by 33%)": false,
-					"Crippling (Lengthens Crippled duration on foes by 33%)": false,
-					"Poisonous (Lengthens Poison duration on foes by 33%)": false,
-					"Silencing (Lengthens Dazed duration on foes by 33%)": false,
-					"Sundering (Armor penetration +20% - Chance 20%)": false,
-					"Vampiric 5 (Life Draining 5 Health regeneration -1)": false,
-					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": false
+					"Ebon (Earth damage)": "ignore",
+					"Fiery (Fire damage)": "ignore",
+					"Icy (Cold damage)": "ignore",
+					"Shocking (Lightning damage)": "ignore",
+					"Barbed (Lengthens Bleeding duration on foes by 33%)": "ignore",
+					"Crippling (Lengthens Crippled duration on foes by 33%)": "ignore",
+					"Poisonous (Lengthens Poison duration on foes by 33%)": "ignore",
+					"Silencing (Lengthens Dazed duration on foes by 33%)": "ignore",
+					"Sundering (Armor penetration +20% - Chance 20%)": "ignore",
+					"Vampiric 5 (Life Draining 5 Health regeneration -1)": "ignore",
+					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": "ignore"
 				},
 				"Suffix - Grip": {
-					"of Fortitude (Health +30)": false,
-					"Of Defense (Armor +5)": false,
-					"Of Shelter (Armor +7 vs physical damage)": false,
-					"Of Warding (Armor +7 vs elemental damage)": false,
-					"Of Enchanting (Enchantments last 20% longer)": false,
-					"Of The Warrior": false,
-					"Of The Ranger": false,
-					"Of The Necromancer": false,
-					"Of The Mesmer": false,
-					"Of The Elementalist": false,
-					"Of The Monk": false,
-					"Of The Ritualist": false,
-					"Of The Assassin": false,
-					"Of The Paragon": false,
-					"Of The Dervish": false,
-					"Of Deathbane": false,
-					"Of Charrslaying": true,
-					"Of Trollslaying": true,
-					"Of Pruning": true,
-					"Of Skeleton Slaying": true,
-					"Of Giant Slaying": true,
-					"Of Dwarf Slaying": true,
-					"Of Tengu Slaying": true,
-					"Of Demon Slaying": true,
-					"Of Ogre Slaying": true,
-					"Of Dragon Slaying": true,
-					"Of Marksmanship (Item's attribute +1 - 20% chance while using skills)": false
+					"of Fortitude (Health +30)": "ignore",
+					"Of Defense (Armor +5)": "ignore",
+					"Of Shelter (Armor +7 vs physical damage)": "ignore",
+					"Of Warding (Armor +7 vs elemental damage)": "ignore",
+					"Of Enchanting (Enchantments last 20% longer)": "ignore",
+					"Of The Warrior": "ignore",
+					"Of The Ranger": "ignore",
+					"Of The Necromancer": "ignore",
+					"Of The Mesmer": "ignore",
+					"Of The Elementalist": "ignore",
+					"Of The Monk": "ignore",
+					"Of The Ritualist": "ignore",
+					"Of The Assassin": "ignore",
+					"Of The Paragon": "ignore",
+					"Of The Dervish": "ignore",
+					"Of Deathbane": "ignore",
+					"Of Charrslaying": "salvage+store",
+					"Of Trollslaying": "salvage+store",
+					"Of Pruning": "salvage+store",
+					"Of Skeleton Slaying": "salvage+store",
+					"Of Giant Slaying": "salvage+store",
+					"Of Dwarf Slaying": "salvage+store",
+					"Of Tengu Slaying": "salvage+store",
+					"Of Demon Slaying": "salvage+store",
+					"Of Ogre Slaying": "salvage+store",
+					"Of Dragon Slaying": "salvage+store",
+					"Of Marksmanship (Item's attribute +1 - 20% chance while using skills)": "ignore"
 				}
 			},
 			"Dagger": {
 				"Prefix - Tang": {
-					"Ebon (Earth damage)": false,
-					"Fiery (Fire damage)": false,
-					"Icy (Cold damage)": false,
-					"Shocking (Lightning damage)": false,
-					"Barbed (Lengthens Bleeding duration on foes by 33%)": false,
-					"Cruel (Lengthens Deep Wound duration on foes by 33%)": false,
-					"Crippling (Lengthens Crippled duration on foes by 33%)": false,
-					"Poisonous (Lengthens Poison duration on foes by 33%)": false,
-					"Silencing (Lengthens Dazed duration on foes by 33%)": false,
-					"Furious (Double Adrenaline on hit - Chance 10%)": false,
-					"Sundering (Armor penetration +20% - Chance 20%)": false,
-					"Vampiric 3 (Life Draining 3 Health regeneration -1)": false,
-					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": false
+					"Ebon (Earth damage)": "ignore",
+					"Fiery (Fire damage)": "ignore",
+					"Icy (Cold damage)": "ignore",
+					"Shocking (Lightning damage)": "ignore",
+					"Barbed (Lengthens Bleeding duration on foes by 33%)": "ignore",
+					"Cruel (Lengthens Deep Wound duration on foes by 33%)": "ignore",
+					"Crippling (Lengthens Crippled duration on foes by 33%)": "ignore",
+					"Poisonous (Lengthens Poison duration on foes by 33%)": "ignore",
+					"Silencing (Lengthens Dazed duration on foes by 33%)": "ignore",
+					"Furious (Double Adrenaline on hit - Chance 10%)": "ignore",
+					"Sundering (Armor penetration +20% - Chance 20%)": "ignore",
+					"Vampiric 3 (Life Draining 3 Health regeneration -1)": "ignore",
+					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": "ignore"
 				},
 				"Suffix - Handle": {
-					"of Fortitude (Health +30)": false,
-					"Of Defense (Armor +5)": false,
-					"Of Shelter (Armor +7 vs physical damage)": false,
-					"Of Warding (Armor +7 vs elemental damage)": false,
-					"Of Enchanting (Enchantments last 20% longer)": false,
-					"Of The Warrior": false,
-					"Of The Ranger": false,
-					"Of The Necromancer": false,
-					"Of The Mesmer": false,
-					"Of The Elementalist": false,
-					"Of The Monk": false,
-					"Of The Ritualist": false,
-					"Of The Assassin": false,
-					"Of The Paragon": false,
-					"Of The Dervish": false,
-					"Of Dagger Mastery (Item's attribute +1 - 20% chance while using skills)": false
+					"of Fortitude (Health +30)": "ignore",
+					"Of Defense (Armor +5)": "ignore",
+					"Of Shelter (Armor +7 vs physical damage)": "ignore",
+					"Of Warding (Armor +7 vs elemental damage)": "ignore",
+					"Of Enchanting (Enchantments last 20% longer)": "ignore",
+					"Of The Warrior": "ignore",
+					"Of The Ranger": "ignore",
+					"Of The Necromancer": "ignore",
+					"Of The Mesmer": "ignore",
+					"Of The Elementalist": "ignore",
+					"Of The Monk": "ignore",
+					"Of The Ritualist": "ignore",
+					"Of The Assassin": "ignore",
+					"Of The Paragon": "ignore",
+					"Of The Dervish": "ignore",
+					"Of Dagger Mastery (Item's attribute +1 - 20% chance while using skills)": "ignore"
 				}
 			},
 			"Focus": {
 				"Suffix - Core": {
-					"of Fortitude (Health +30)": true,
-					"Of Devotion (Health +45 while Enchanted)": false,
-					"Of Endurance (Health +45 while in a Stance)": false,
-					"Of Valor (Health +60 while Hexed)": false,
-					"Of Aptitude (Halves casting time of item's attribute spells - Chance 20%)": true,
-					"Of Swiftness (Halves casting time of spells - Chance 10%)": false
+					"of Fortitude (Health +30)": "salvage+store",
+					"Of Devotion (Health +45 while Enchanted)": "ignore",
+					"Of Endurance (Health +45 while in a Stance)": "ignore",
+					"Of Valor (Health +60 while Hexed)": "ignore",
+					"Of Aptitude (Halves casting time of item's attribute spells - Chance 20%)": "salvage+store",
+					"Of Swiftness (Halves casting time of spells - Chance 10%)": "ignore"
 				}
 			},
 			"Hammer": {
 				"Prefix - Haft": {
-					"Ebon (Earth damage)": false,
-					"Fiery (Fire damage)": false,
-					"Icy (Cold damage)": false,
-					"Shocking (Lightning damage)": false,
-					"Cruel (Lengthens Deep Wound duration on foes by 33%)": false,
-					"Heavy (Lengthens Weakness duration on foes by 33%)": false,
-					"Furious (Double Adrenaline on hit - Chance 10%)": false,
-					"Sundering (Armor penetration +20% - Chance 20%)": false,
-					"Vampiric 5 (Life Draining 5 Health regeneration -1)": false,
-					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": false
+					"Ebon (Earth damage)": "ignore",
+					"Fiery (Fire damage)": "ignore",
+					"Icy (Cold damage)": "ignore",
+					"Shocking (Lightning damage)": "ignore",
+					"Cruel (Lengthens Deep Wound duration on foes by 33%)": "ignore",
+					"Heavy (Lengthens Weakness duration on foes by 33%)": "ignore",
+					"Furious (Double Adrenaline on hit - Chance 10%)": "ignore",
+					"Sundering (Armor penetration +20% - Chance 20%)": "ignore",
+					"Vampiric 5 (Life Draining 5 Health regeneration -1)": "ignore",
+					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": "ignore"
 				},
 				"Suffix - Grip": {
-					"of Fortitude (Health +30)": false,
-					"Of Defense (Armor +5)": false,
-					"Of Shelter (Armor +7 vs physical damage)": false,
-					"Of Warding (Armor +7 vs elemental damage)": false,
-					"Of Enchanting (Enchantments last 20% longer)": false,
-					"Of The Warrior": false,
-					"Of The Ranger": false,
-					"Of The Necromancer": false,
-					"Of The Mesmer": false,
-					"Of The Elementalist": false,
-					"Of The Monk": false,
-					"Of The Ritualist": false,
-					"Of The Assassin": false,
-					"Of The Paragon": false,
-					"Of The Dervish": false,
-					"Of Deathbane": false,
-					"Of Charrslaying": true,
-					"Of Trollslaying": true,
-					"Of Pruning": true,
-					"Of Skeleton Slaying": true,
-					"Of Giant Slaying": true,
-					"Of Dwarf Slaying": true,
-					"Of Tengu Slaying": true,
-					"Of Demon Slaying": true,
-					"Of Ogre Slaying": true,
-					"Of Dragon Slaying": true,
-					"Of Hammer Mastery (Item's attribute +1 - 20% chance while using skills)": false
+					"of Fortitude (Health +30)": "ignore",
+					"Of Defense (Armor +5)": "ignore",
+					"Of Shelter (Armor +7 vs physical damage)": "ignore",
+					"Of Warding (Armor +7 vs elemental damage)": "ignore",
+					"Of Enchanting (Enchantments last 20% longer)": "ignore",
+					"Of The Warrior": "ignore",
+					"Of The Ranger": "ignore",
+					"Of The Necromancer": "ignore",
+					"Of The Mesmer": "ignore",
+					"Of The Elementalist": "ignore",
+					"Of The Monk": "ignore",
+					"Of The Ritualist": "ignore",
+					"Of The Assassin": "ignore",
+					"Of The Paragon": "ignore",
+					"Of The Dervish": "ignore",
+					"Of Deathbane": "ignore",
+					"Of Charrslaying": "salvage+store",
+					"Of Trollslaying": "salvage+store",
+					"Of Pruning": "salvage+store",
+					"Of Skeleton Slaying": "salvage+store",
+					"Of Giant Slaying": "salvage+store",
+					"Of Dwarf Slaying": "salvage+store",
+					"Of Tengu Slaying": "salvage+store",
+					"Of Demon Slaying": "salvage+store",
+					"Of Ogre Slaying": "salvage+store",
+					"Of Dragon Slaying": "salvage+store",
+					"Of Hammer Mastery (Item's attribute +1 - 20% chance while using skills)": "ignore"
 				}
 			},
 			"Scythe": {
 				"Prefix - Snathe": {
-					"Ebon (Earth damage)": false,
-					"Fiery (Fire damage)": false,
-					"Icy (Cold damage)": false,
-					"Shocking (Lightning damage)": false,
-					"Barbed (Lengthens Bleeding duration on foes by 33%)": false,
-					"Cruel (Lengthens Deep Wound duration on foes by 33%)": false,
-					"Crippling (Lengthens Crippled duration on foes by 33%)": false,
-					"Heavy (Lengthens Weakness duration on foes by 33%)": false,
-					"Poisonous (Lengthens Poison duration on foes by 33%)": false,
-					"Furious (Double Adrenaline on hit - Chance 10%)": false,
-					"Sundering (Armor penetration +20% - Chance 20%)": false,
-					"Vampiric 5 (Life Draining 5 Health regeneration -1)": false,
-					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": false
+					"Ebon (Earth damage)": "ignore",
+					"Fiery (Fire damage)": "ignore",
+					"Icy (Cold damage)": "ignore",
+					"Shocking (Lightning damage)": "ignore",
+					"Barbed (Lengthens Bleeding duration on foes by 33%)": "ignore",
+					"Cruel (Lengthens Deep Wound duration on foes by 33%)": "ignore",
+					"Crippling (Lengthens Crippled duration on foes by 33%)": "ignore",
+					"Heavy (Lengthens Weakness duration on foes by 33%)": "ignore",
+					"Poisonous (Lengthens Poison duration on foes by 33%)": "ignore",
+					"Furious (Double Adrenaline on hit - Chance 10%)": "ignore",
+					"Sundering (Armor penetration +20% - Chance 20%)": "ignore",
+					"Vampiric 5 (Life Draining 5 Health regeneration -1)": "ignore",
+					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": "ignore"
 				},
 				"Suffix - Grip": {
-					"of Fortitude (Health +30)": false,
-					"Of Defense (Armor +5)": false,
-					"Of Shelter (Armor +7 vs physical damage)": false,
-					"Of Warding (Armor +7 vs elemental damage)": false,
-					"Of Enchanting (Enchantments last 20% longer)": false,
-					"Of The Warrior": false,
-					"Of The Ranger": false,
-					"Of The Necromancer": false,
-					"Of The Mesmer": false,
-					"Of The Elementalist": false,
-					"Of The Monk": false,
-					"Of The Ritualist": false,
-					"Of The Assassin": false,
-					"Of The Paragon": false,
-					"Of The Dervish": false,
-					"Of Scythe Mastery (Item's attribute +1 - 20% chance while using skills)": false
+					"of Fortitude (Health +30)": "ignore",
+					"Of Defense (Armor +5)": "ignore",
+					"Of Shelter (Armor +7 vs physical damage)": "ignore",
+					"Of Warding (Armor +7 vs elemental damage)": "ignore",
+					"Of Enchanting (Enchantments last 20% longer)": "ignore",
+					"Of The Warrior": "ignore",
+					"Of The Ranger": "ignore",
+					"Of The Necromancer": "ignore",
+					"Of The Mesmer": "ignore",
+					"Of The Elementalist": "ignore",
+					"Of The Monk": "ignore",
+					"Of The Ritualist": "ignore",
+					"Of The Assassin": "ignore",
+					"Of The Paragon": "ignore",
+					"Of The Dervish": "ignore",
+					"Of Scythe Mastery (Item's attribute +1 - 20% chance while using skills)": "ignore"
 				}
 			},
 			"Shield": {
 				"Suffix - Handle": {
-					"of Fortitude (Health +30)": false,
-					"Of Devotion (Health +45 while Enchanted)": false,
-					"Of Endurance (Health +45 while in a Stance)": false,
-					"Of Valor (Health +60 while Hexed)": false
+					"of Fortitude (Health +30)": "ignore",
+					"Of Devotion (Health +45 while Enchanted)": "ignore",
+					"Of Endurance (Health +45 while in a Stance)": "ignore",
+					"Of Valor (Health +60 while Hexed)": "ignore"
 				}
 			},
 			"Spear": {
 				"Prefix - Head": {
-					"Ebon (Earth damage)": false,
-					"Fiery (Fire damage)": false,
-					"Icy (Cold damage)": false,
-					"Shocking (Lightning damage)": false,
-					"Barbed (Lengthens Bleeding duration on foes by 33%)": false,
-					"Cruel (Lengthens Deep Wound duration on foes by 33%)": false,
-					"Crippling (Lengthens Crippled duration on foes by 33%)": false,
-					"Heavy (Lengthens Weakness duration on foes by 33%)": false,
-					"Poisonous (Lengthens Poison duration on foes by 33%)": false,
-					"Silencing (Lengthens Dazed duration on foes by 33%)": false,
-					"Furious (Double Adrenaline on hit - Chance 10%)": false,
-					"Sundering (Armor penetration +20% - Chance 20%)": false,
-					"Vampiric 3 (Life Draining 3 Health regeneration -1)": false,
-					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": false
+					"Ebon (Earth damage)": "ignore",
+					"Fiery (Fire damage)": "ignore",
+					"Icy (Cold damage)": "ignore",
+					"Shocking (Lightning damage)": "ignore",
+					"Barbed (Lengthens Bleeding duration on foes by 33%)": "ignore",
+					"Cruel (Lengthens Deep Wound duration on foes by 33%)": "ignore",
+					"Crippling (Lengthens Crippled duration on foes by 33%)": "ignore",
+					"Heavy (Lengthens Weakness duration on foes by 33%)": "ignore",
+					"Poisonous (Lengthens Poison duration on foes by 33%)": "ignore",
+					"Silencing (Lengthens Dazed duration on foes by 33%)": "ignore",
+					"Furious (Double Adrenaline on hit - Chance 10%)": "ignore",
+					"Sundering (Armor penetration +20% - Chance 20%)": "ignore",
+					"Vampiric 3 (Life Draining 3 Health regeneration -1)": "ignore",
+					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": "ignore"
 				},
 				"Suffix - Grip": {
-					"of Fortitude (Health +30)": false,
-					"Of Defense (Armor +5)": false,
-					"Of Shelter (Armor +7 vs physical damage)": false,
-					"Of Warding (Armor +7 vs elemental damage)": false,
-					"Of Enchanting (Enchantments last 20% longer)": true,
-					"Of The Warrior": false,
-					"Of The Ranger": false,
-					"Of The Necromancer": false,
-					"Of The Mesmer": false,
-					"Of The Elementalist": false,
-					"Of The Monk": false,
-					"Of The Ritualist": false,
-					"Of The Assassin": false,
-					"Of The Paragon": false,
-					"Of The Dervish": false,
-					"Of Spear Mastery (Item's attribute +1 - 20% chance while using skills)": false
+					"of Fortitude (Health +30)": "ignore",
+					"Of Defense (Armor +5)": "ignore",
+					"Of Shelter (Armor +7 vs physical damage)": "ignore",
+					"Of Warding (Armor +7 vs elemental damage)": "ignore",
+					"Of Enchanting (Enchantments last 20% longer)": "salvage+store",
+					"Of The Warrior": "ignore",
+					"Of The Ranger": "ignore",
+					"Of The Necromancer": "ignore",
+					"Of The Mesmer": "ignore",
+					"Of The Elementalist": "ignore",
+					"Of The Monk": "ignore",
+					"Of The Ritualist": "ignore",
+					"Of The Assassin": "ignore",
+					"Of The Paragon": "ignore",
+					"Of The Dervish": "ignore",
+					"Of Spear Mastery (Item's attribute +1 - 20% chance while using skills)": "ignore"
 				}
 			},
 			"Staff": {
 				"Prefix - Head": {
-					"Hale (Health +30)": false,
-					"Adept (Halves casting time of spells of item's attribute - Chance 20%)": false,
-					"Swift (Halves casting time of spells - Chance 10%)": false,
-					"Insightful (Energy +5)": false,
-					"Defensive (Armor +5)": false
+					"Hale (Health +30)": "ignore",
+					"Adept (Halves casting time of spells of item's attribute - Chance 20%)": "ignore",
+					"Swift (Halves casting time of spells - Chance 10%)": "ignore",
+					"Insightful (Energy +5)": "ignore",
+					"Defensive (Armor +5)": "ignore"
 				},
 				"Suffix - Wrapping": {
-					"of Fortitude (Health +30)": false,
-					"Of Defense (Armor +5)": false,
-					"Of Shelter (Armor +7 vs physical damage)": false,
-					"Of Warding (Armor +7 vs elemental damage)": false,
-					"Of Enchanting (Enchantments last 20% longer)": false,
-					"Of The Warrior": false,
-					"Of The Ranger": false,
-					"Of The Necromancer": true,
-					"Of The Mesmer": false,
-					"Of The Elementalist": false,
-					"Of The Monk": false,
-					"Of The Ritualist": true,
-					"Of The Assassin": false,
-					"Of The Paragon": false,
-					"Of The Dervish": false,
-					"Of Deathbane": false,
-					"Of Charrslaying": true,
-					"Of Trollslaying": true,
-					"Of Pruning": true,
-					"Of Skeleton Slaying": true,
-					"Of Giant Slaying": true,
-					"Of Dwarf Slaying": true,
-					"Of Tengu Slaying": true,
-					"Of Demon Slaying": true,
-					"Of Ogre Slaying": true,
-					"Of Dragon Slaying": true,
-					"Of Mastery (Item's attribute +1 - 20% chance while using skills)": false,
-					"Of Devotion (Health +45 while Enchanted)": false,
-					"Of Endurance (Health +45 while in a Stance)": false,
-					"Of Valor (Health +60 while Hexed)": false
+					"of Fortitude (Health +30)": "ignore",
+					"Of Defense (Armor +5)": "ignore",
+					"Of Shelter (Armor +7 vs physical damage)": "ignore",
+					"Of Warding (Armor +7 vs elemental damage)": "ignore",
+					"Of Enchanting (Enchantments last 20% longer)": "ignore",
+					"Of The Warrior": "ignore",
+					"Of The Ranger": "ignore",
+					"Of The Necromancer": "salvage+store",
+					"Of The Mesmer": "ignore",
+					"Of The Elementalist": "ignore",
+					"Of The Monk": "ignore",
+					"Of The Ritualist": "salvage+store",
+					"Of The Assassin": "ignore",
+					"Of The Paragon": "ignore",
+					"Of The Dervish": "ignore",
+					"Of Deathbane": "ignore",
+					"Of Charrslaying": "salvage+store",
+					"Of Trollslaying": "salvage+store",
+					"Of Pruning": "salvage+store",
+					"Of Skeleton Slaying": "salvage+store",
+					"Of Giant Slaying": "salvage+store",
+					"Of Dwarf Slaying": "salvage+store",
+					"Of Tengu Slaying": "salvage+store",
+					"Of Demon Slaying": "salvage+store",
+					"Of Ogre Slaying": "salvage+store",
+					"Of Dragon Slaying": "salvage+store",
+					"Of Mastery (Item's attribute +1 - 20% chance while using skills)": "ignore",
+					"Of Devotion (Health +45 while Enchanted)": "ignore",
+					"Of Endurance (Health +45 while in a Stance)": "ignore",
+					"Of Valor (Health +60 while Hexed)": "ignore"
 				}
 			},
 			"Sword": {
 				"Prefix - Hilt": {
-					"Ebon (Earth damage)": false,
-					"Fiery (Fire damage)": false,
-					"Icy (Cold damage)": false,
-					"Shocking (Lightning damage)": false,
-					"Barbed (Lengthens Bleeding duration on foes by 33%)": false,
-					"Cruel (Lengthens Deep Wound duration on foes by 33%)": false,
-					"Crippling (Lengthens Crippled duration on foes by 33%)": false,
-					"Poisonous (Lengthens Poison duration on foes by 33%)": false,
-					"Furious (Double Adrenaline on hit - Chance 10%)": false,
-					"Sundering (Armor penetration +20% - Chance 20%)": false,
-					"Vampiric 3 (Life Draining 3 Health regeneration -1)": false,
-					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": false
+					"Ebon (Earth damage)": "ignore",
+					"Fiery (Fire damage)": "ignore",
+					"Icy (Cold damage)": "ignore",
+					"Shocking (Lightning damage)": "ignore",
+					"Barbed (Lengthens Bleeding duration on foes by 33%)": "ignore",
+					"Cruel (Lengthens Deep Wound duration on foes by 33%)": "ignore",
+					"Crippling (Lengthens Crippled duration on foes by 33%)": "ignore",
+					"Poisonous (Lengthens Poison duration on foes by 33%)": "ignore",
+					"Furious (Double Adrenaline on hit - Chance 10%)": "ignore",
+					"Sundering (Armor penetration +20% - Chance 20%)": "ignore",
+					"Vampiric 3 (Life Draining 3 Health regeneration -1)": "ignore",
+					"Zealous (Energy gain on hit: 1 Energy regeneration: -1)": "ignore"
 				},
 				"Suffix - Pommel": {
-					"of Fortitude (Health +30)": false,
-					"Of Defense (Armor +5)": false,
-					"Of Shelter (Armor +7 vs physical damage)": false,
-					"Of Warding (Armor +7 vs elemental damage)": false,
-					"Of Enchanting (Enchantments last 20% longer)": false,
-					"Of The Warrior": false,
-					"Of The Ranger": false,
-					"Of The Necromancer": false,
-					"Of The Mesmer": false,
-					"Of The Elementalist": false,
-					"Of The Monk": false,
-					"Of The Ritualist": false,
-					"Of The Assassin": false,
-					"Of The Paragon": false,
-					"Of The Dervish": false,
-					"Of Deathbane": false,
-					"Of Charrslaying": true,
-					"Of Trollslaying": true,
-					"Of Pruning": true,
-					"Of Skeleton Slaying": true,
-					"Of Giant Slaying": true,
-					"Of Dwarf Slaying": true,
-					"Of Tengu Slaying": true,
-					"Of Demon Slaying": true,
-					"Of Ogre Slaying": true,
-					"Of Dragon Slaying": true,
-					"Of Swordmanship (Item's attribute +1 - 20% chance while using skills)": false
+					"of Fortitude (Health +30)": "ignore",
+					"Of Defense (Armor +5)": "ignore",
+					"Of Shelter (Armor +7 vs physical damage)": "ignore",
+					"Of Warding (Armor +7 vs elemental damage)": "ignore",
+					"Of Enchanting (Enchantments last 20% longer)": "ignore",
+					"Of The Warrior": "ignore",
+					"Of The Ranger": "ignore",
+					"Of The Necromancer": "ignore",
+					"Of The Mesmer": "ignore",
+					"Of The Elementalist": "ignore",
+					"Of The Monk": "ignore",
+					"Of The Ritualist": "ignore",
+					"Of The Assassin": "ignore",
+					"Of The Paragon": "ignore",
+					"Of The Dervish": "ignore",
+					"Of Deathbane": "ignore",
+					"Of Charrslaying": "salvage+store",
+					"Of Trollslaying": "salvage+store",
+					"Of Pruning": "salvage+store",
+					"Of Skeleton Slaying": "salvage+store",
+					"Of Giant Slaying": "salvage+store",
+					"Of Dwarf Slaying": "salvage+store",
+					"Of Tengu Slaying": "salvage+store",
+					"Of Demon Slaying": "salvage+store",
+					"Of Ogre Slaying": "salvage+store",
+					"Of Dragon Slaying": "salvage+store",
+					"Of Swordmanship (Item's attribute +1 - 20% chance while using skills)": "ignore"
 				}
 			},
 			"Wand": {
 				"Suffix - Wrapping": {
-					"Of Memory (Halves skill recharge of item's attribute spells - Chance 20%)": false,
-					"Of Quickening (Halves skill recharge of spells - Chance 10%)": false,
-					"Of The Warrior": false,
-					"Of The Ranger": false,
-					"Of The Necromancer": true,
-					"Of The Mesmer": false,
-					"Of The Elementalist": false,
-					"Of The Monk": false,
-					"Of The Ritualist": true,
-					"Of The Assassin": false,
-					"Of The Paragon": false,
-					"Of The Dervish": false
+					"Of Memory (Halves skill recharge of item's attribute spells - Chance 20%)": "ignore",
+					"Of Quickening (Halves skill recharge of spells - Chance 10%)": "ignore",
+					"Of The Warrior": "ignore",
+					"Of The Ranger": "ignore",
+					"Of The Necromancer": "salvage+store",
+					"Of The Mesmer": "ignore",
+					"Of The Elementalist": "ignore",
+					"Of The Monk": "ignore",
+					"Of The Ritualist": "salvage+store",
+					"Of The Assassin": "ignore",
+					"Of The Paragon": "ignore",
+					"Of The Dervish": "ignore"
 				}
 			}
 		}
-	},
-	"Salvage items": {
-		"Weapons and offhands": {
-			"White": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
-			},
-			"Blue": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
-			},
-			"Purple": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
-			},
-			"Gold": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
-			}
-		},
-		"Armor salvageables": {
-			"White": false,
-			"Blue": false,
-			"Purple": false,
-			"Gold": false
-		},
-		"Rare Materials": {
-			"Fur Square": false,
-			"Bolt of Linen": false,
-			"Bolt of Damask": false,
-			"Bolt of Silk": false,
-			"Glob of Ectoplasm": false,
-			"Steel Ingot": true,
-			"Deldrimor Steel Ingot": false,
-			"Monstrous Claw": false,
-			"Monstrous Eye": false,
-			"Monstrous Fang": false,
-			"Ruby": false,
-			"Sapphire": false,
-			"Diamond": false,
-			"Onyx Gemstone": false,
-			"Lump of Charcoal": false,
-			"Obsidian Shard": false,
-			"Tempered Glass Vial": false,
-			"Leather Square": false,
-			"Elonian Leather Square": false,
-			"Vial of Ink": false,
-			"Roll of Parchment": false,
-			"Roll of Vellum": false,
-			"Spiritwood Plank": false,
-			"Amber Chunk": false,
-			"Jadeite Shard": false
-		},
-		"Trophies": {
-			"Superb Charr Carving": false,
-			"Chunk of Drake Flesh": false,
-			"Skale Fin": false,
-			"Iboga Petal": false,
-			"Destroyer Core": false,
-			"Glacial Stone": true,
-			"Saurian Bone": true,
-			"Jade Bracelet": false,
-			"Dark Remains": true,
-			"Demonic Remains": true
-		}
-	},
-	"Sell items": {
-		"Weapons and offhands": {
-			"White": {
-				"Axe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Bow": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Dagger": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Focus": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Hammer": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Scythe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Shield": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Spear": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Staff": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Sword": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Wand": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				}
-			},
-			"Blue": {
-				"Axe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Bow": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Dagger": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Focus": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Hammer": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Scythe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Shield": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Spear": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Staff": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Sword": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Wand": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				}
-			},
-			"Purple": {
-				"Axe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Bow": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Dagger": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Focus": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Hammer": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Scythe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Shield": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Spear": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Staff": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Sword": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Wand": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				}
-			},
-			"Gold": {
-				"Axe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Bow": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Dagger": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Focus": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Hammer": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Scythe": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Shield": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Spear": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Staff": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Sword": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				},
-				"Wand": {
-					"Req 0": true,
-					"Req 1": true,
-					"Req 2": true,
-					"Req 3": true,
-					"Req 4": true,
-					"Req 5": true,
-					"Req 6": true,
-					"Req 7": true,
-					"Req 8": true,
-					"Req 9": true,
-					"Req 10": true,
-					"Req 11": true,
-					"Req 12": true,
-					"Req 13": true
-				}
-			}
-		},
-		"Armor salvageables": {
-			"White": true,
-			"Blue": true,
-			"Purple": true,
-			"Gold": true
-		},
-		"Basic Materials": {
-			"Bone": false,
-			"Bolt of Cloth": false,
-			"Chitin Fragment": false,
-			"Feather": false,
-			"Granite Slab": false,
-			"Iron Ingot": false,
-			"Pile of Glittering Dust": false,
-			"Plant Fiber": false,
-			"Scale": false,
-			"Tanned Hide Square": false,
-			"Wood Plank": false
-		},
-		"Rare Materials": {
-			"Fur Square": false,
-			"Bolt of Linen": false,
-			"Bolt of Damask": false,
-			"Bolt of Silk": false,
-			"Glob of Ectoplasm": false,
-			"Steel Ingot": false,
-			"Deldrimor Steel Ingot": false,
-			"Monstrous Claw": false,
-			"Monstrous Eye": false,
-			"Monstrous Fang": false,
-			"Ruby": false,
-			"Sapphire": false,
-			"Diamond": false,
-			"Onyx Gemstone": false,
-			"Lump of Charcoal": false,
-			"Obsidian Shard": false,
-			"Tempered Glass Vial": false,
-			"Leather Square": false,
-			"Elonian Leather Square": false,
-			"Vial of Ink": false,
-			"Roll of Parchment": false,
-			"Roll of Vellum": false,
-			"Spiritwood Plank": false,
-			"Amber Chunk": false,
-			"Jadeite Shard": false
-		},
-		"Trophies": {
-			"Superb Charr Carving": false,
-			"Chunk of Drake Flesh": false,
-			"Skale Fin": false,
-			"Iboga Petal": false,
-			"Destroyer Core": false,
-			"Glacial Stone": false,
-			"Saurian Bone": false,
-			"Jade Bracelet": false,
-			"Dark Remains": false,
-			"Demonic Remains": false
-		},
-		"Scrolls": {
-			"Blue": true,
-			"Gold": {
-				"Passage Scroll to the Fissure of Woe": false,
-				"Passage Scroll to the Underworld": false,
-				"Passage Scroll to the Deep": false,
-				"Passage Scroll to Urgozs Warren": false,
-				"Other gold scrolls": true
-			}
-		},
-		"Keys": true
 	},
 	"Buy items": {
 		"Lockpicks": false,
@@ -3357,1123 +3539,5 @@
 			"Amber Chunk": false,
 			"Jadeite Shard": false
 		}
-	},
-	"Store items": {
-		"Gold": true,
-		"Consumables": true,
-		"Alcohols": {
-			"Minor (1pt)": true,
-			"Major (3pt)": true,
-			"Superior (50pt)": true
-		},
-		"Party": {
-			"Minor (1-2pt)": true,
-			"Major (3-7pt)": true,
-			"Superior (25-50pt)": true
-		},
-		"Sweets": {
-			"Minor (1-2pt)": true,
-			"Major (3pt)": true,
-			"Superior (50pt)": true
-		},
-		"PCons": {
-			"Drake Kabob": true,
-			"Bowl of Skalefin Soup": true,
-			"Pahnai Salad": true,
-			"Birthday Cupcake": false,
-			"Golden Egg": true,
-			"Candy Apple": true,
-			"Candy Corn": true,
-			"Slice of Pumpkin Pie": false,
-			"Blue Rock Candy": true,
-			"Green Rock Candy": true,
-			"Red Rock Candy": true,
-			"War Supplies": true,
-			"Lunar Fortune (Pig)": true,
-			"Lunar Fortune (Rat)": true,
-			"Lunar Fortune (Ox)": true,
-			"Lunar Fortune (Tiger)": true,
-			"Lunar Fortune (Rabbit)": true,
-			"Lunar Fortune (Dragon)": true,
-			"Lunar Fortune (Snake)": true,
-			"Lunar Fortune (Horse)": true,
-			"Lunar Fortune (Sheep)": true,
-			"Lunar Fortune (Monkey)": true,
-			"Lunar Fortune (Rooster)": true,
-			"Lunar Fortune (Dog)": true
-		},
-		"Morale": {
-			"Peppermint Candy Cane": true,
-			"Refined Jelly": true,
-			"Elixir of Valor": true,
-			"Wintergreen Candy Cane": true,
-			"Rainbow Candy Cane": true,
-			"Four Leaf Clover": true,
-			"Honeycomb": false,
-			"Pumpkin Cookie": true,
-			"Oath of Purity": true,
-			"Seal of the Dragon Empire": true,
-			"Shining Blade Ration": true
-		},
-		"Special drops": {
-			"Candy Cane Shard": true,
-			"Victory Token": true,
-			"Wintersday Gift": true,
-			"Wayfarer Mark": true,
-			"Lunar Token": true,
-			"Lunar Tokens": true,
-			"Trick-or-Treat Bag": true,
-			"Flame of Balthazar": true,
-			"Golden Flame of Balthazar": true,
-			"Celestial Sigil": true,
-			"Stalkers Rations": true,
-			"Birds Eye Compass": true
-		},
-		"Summoning stones": {
-			"Cracked Ascalonian War Horn": false,
-			"Igneous Summoning Stone": false,
-			"Legionnaire Summoning Crystal": false,
-			"Ghastly Summon": false,
-			"Mystical Summon": false,
-			"Tengu Summon": false,
-			"Imperial Guard Summon": false,
-			"Automaton Summon": false,
-			"Chitinous Summon": false,
-			"Amber Summon": false,
-			"Arctic Summon": false,
-			"Demonic Summon": false,
-			"Gelatinous Summon": false,
-			"Fossilized Summon": false,
-			"Jadeite Summon": false,
-			"Mischievous Summon": false,
-			"Frosty Summon": false,
-			"Zaishen Summon": false,
-			"Celestial Summon": false,
-			"Shining Blade Summon": false,
-			"Mysterious Summon": false,
-			"Merchant Summon": false
-		},
-		"Consets": {			
-			"Heroes Trifecta": false,
-			"Essence of Celerity": false,
-			"Armor of Salvation": false,
-			"Grail of Might": false,
-			"Scroll of Resurrection": false,
-			"Empowering Feasts": false
-		},
-		"Unidentified gold items": false,
-		"Weapons and offhands": {
-			"White": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
-			},
-			"Blue": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
-			},
-			"Purple": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
-			},
-			"Gold": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
-			},
-			"Green": {
-				"Axe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Bow": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Dagger": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Focus": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Hammer": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Scythe": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Shield": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Spear": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Staff": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Sword": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				},
-				"Wand": {
-					"Req 0": false,
-					"Req 1": false,
-					"Req 2": false,
-					"Req 3": false,
-					"Req 4": false,
-					"Req 5": false,
-					"Req 6": false,
-					"Req 7": false,
-					"Req 8": false,
-					"Req 9": false,
-					"Req 10": false,
-					"Req 11": false,
-					"Req 12": false,
-					"Req 13": false
-				}
-			}
-		},
-		"Armor salvageables": {
-			"White": false,
-			"Blue": false,
-			"Purple": false,
-			"Gold": false
-		},
-		"Upgrade components": true,
-		"Basic Materials": {
-			"Bone": true,
-			"Bolt of Cloth": true,
-			"Chitin Fragment": true,
-			"Feather": true,
-			"Granite Slab": true,
-			"Iron Ingot": true,
-			"Pile of Glittering Dust": true,
-			"Plant Fiber": true,
-			"Scale": true,
-			"Tanned Hide Square": true,
-			"Wood Plank": true
-		},
-		"Rare Materials": {
-			"Fur Square": true,
-			"Bolt of Linen": true,
-			"Bolt of Damask": true,
-			"Bolt of Silk": true,
-			"Glob of Ectoplasm": true,
-			"Steel Ingot": true,
-			"Deldrimor Steel Ingot": true,
-			"Monstrous Claw": true,
-			"Monstrous Eye": true,
-			"Monstrous Fang": true,
-			"Ruby": true,
-			"Sapphire": true,
-			"Diamond": true,
-			"Onyx Gemstone": true,
-			"Lump of Charcoal": true,
-			"Obsidian Shard": true,
-			"Tempered Glass Vial": true,
-			"Leather Square": true,
-			"Elonian Leather Square": true,
-			"Vial of Ink": true,
-			"Roll of Parchment": true,
-			"Roll of Vellum": true,
-			"Spiritwood Plank": true,
-			"Amber Chunk": true,
-			"Jadeite Shard": true
-		},
-		"Trophies": {
-			"Margonite Gemstone": true,
-			"Stygian Gemstone": true,
-			"Titan Gemstone": true,
-			"Torment Gemstone": true,
-			"Diessa Chalice": true,
-			"Golden Rin Relic": true,
-			"Superb Charr Carving": true,
-			"Chunk of Drake Flesh": true,
-			"Skale Fin": true,
-			"Iboga Petal": true,
-			"Destroyer Core": true,
-			"Glacial Stone": false,
-			"Saurian Bone": false,
-			"Jade Bracelet": true,
-			"Dark Remains": true,
-			"Demonic Remains": true,
-			"Other trophies": true
-		},
-		"Tomes": {
-			"Normal": {
-				"Warrior Tome": true,
-				"Ranger Tome": true,
-				"Monk Tome": true,
-				"Necromancer Tome": true,
-				"Mesmer Tome": true,
-				"Elementalist Tome": true,
-				"Assassin Tome": true,
-				"Ritualist Tome": true,
-				"Paragon Tome": true,
-				"Dervish Tome": true
-			},
-			"Elite": {
-				"Elite Warrior Tome": true,
-				"Elite Ranger Tome": true,
-				"Elite Monk Tome": true,
-				"Elite Necromancer Tome": true,
-				"Elite Mesmer Tome": true,
-				"Elite Elementalist Tome": true,
-				"Elite Assassin Tome": true,
-				"Elite Ritualist Tome": true,
-				"Elite Paragon Tome": true,
-				"Elite Dervish Tome": true
-			}
-		},
-		"Scrolls": {
-			"Blue": false,
-			"Gold": {
-				"Passage Scroll to the Fissure of Woe": true,
-				"Passage Scroll to the Underworld": true,
-				"Passage Scroll to the Deep": true,
-				"Passage Scroll to Urgozs Warren": true,
-				"Other gold scrolls": false
-			}
-		},
-		"Dyes": {
-			"Black": true,
-			"Blue": false,
-			"Brown": false,
-			"Gray": false,
-			"Green": false,
-			"Orange": false,
-			"Pink": false,
-			"Purple": false,
-			"Red": false,
-			"Silver": false,
-			"White": true,
-			"Yellow": false
-		},
-		"Quest items": {
-			"Map pieces": false
-		},
-		"Lockpicks": false,
-		"Keys": false
 	}
 }

--- a/conf/loot/Default Loot Configuration.json
+++ b/conf/loot/Default Loot Configuration.json
@@ -4360,6 +4360,7 @@
 			"Purple": false,
 			"Gold": false
 		},
+		"Upgrade components": true,
 		"Basic Materials": {
 			"Bone": true,
 			"Bolt of Cloth": true,

--- a/doc/rare-skins.md
+++ b/doc/rare-skins.md
@@ -1,0 +1,210 @@
+# Rare weapon skins
+
+Generated from the ID tables in `lib/GWA2_ID_Items.au3` (`$rareWeaponsArray`, `$rareWeaponsToPickUp` and `$ultraRareWeaponsArray`). Variants of a skin (attribute, requirement type, second model ID) are listed once.
+
+How the loot configuration uses these lists:
+
+- In the Inventory tab, a weapon goes to the **Rare skins** leaf of its type, rarity and requirement when its skin is in one of the tables below **and** it has max stats for its requirement. Every other weapon goes to **Other skins**.
+- **Ultra rare** skins are also stored whatever their leaf says, as one of the keep rules.
+- To add a skin, add its model ID to the matching table in the code.
+
+## Ultra rare skins (always stored)
+
+### Axe
+
+- Eaglecrest Axe
+- Envoy Axe
+
+### Sword
+
+- Aureate Blade
+- Crystalline Sword
+- Emerald Blade
+- Envoy Sword
+- Eternal Blade
+- Glacial Blade
+- Glacial Blades
+- Obsidian Edge
+
+### Dagger
+
+- Storm Daggers
+
+### Hammer
+
+- Wingcrest Maul
+
+### Scythe
+
+- Clockwork Scythe
+- Dhuums Soul Reaper
+- Envoy Scythe
+- Insectoid Scythe
+- Tentacle Scythe
+
+### Spear
+
+- Demoncrest Spear
+- Voltaic Spear
+
+### Bow
+
+- Dryad Bow
+- Eternal Bow
+- Silverwing Recurve Bow
+
+### Wand
+
+- Darkhorn Rod
+- Froggy
+- Onyx Scepter
+- Topaz Scepter
+
+### Staff
+
+- Ancient Moss Staff
+- Astral Staff
+- Bone Dragon Staff
+- Chrysocola Staff
+- Cobalt Staff
+- Crystal Flame Staff
+- Divine Envoy Staff
+- Embercrest Staff
+- Ghostly Staff
+- Goldhorn Staff
+- Icicle Staff
+- Insectoid Staff
+- Moldavite Staff
+- Suntouched Staff
+- Turquoise Staff
+
+### Focus
+
+- Celestial Compass
+
+### Shield
+
+- Eternal Shield
+- Signet Shield
+
+### Other
+
+- Demrikovs Judgement
+- Heleynes Insight
+- Torivos Rage
+- Vetauras Harbinger
+
+## Rare skins
+
+### Axe
+
+- Chaos Axe
+- Sephis Axe
+- Serpent Axe
+
+### Sword
+
+- Adamantine Falchion
+- Broadsword
+- Colossal Scimitar
+- Crystalline Sword
+- Dadao Sword
+- Golden Phoenix Blade
+- Jitte
+- Katana
+- Oni Blade
+- Ornate Scimitar
+- Shinobi Blade
+- Tatooed Scimitar
+
+### Hammer
+
+- Colossal Pick
+
+### Scythe
+
+- Draconic Scythe
+
+### Bow
+
+- Eternal Bow
+- Storm Bow
+
+### Wand
+
+- Canthan Targe
+- Canthan Targe Leadership
+- Celestial Axe
+- Celestial Daggers
+- Celestial Hammer
+- Celestial Longbow
+- Celestial Scepter
+- Celestial Shield
+- Celestial Staff
+- Celestial Sword
+- Ceremonial Daggers
+- Dragon Fangs
+- Dragoncrest Axe
+- Gavel Of The Nephilim
+- Ironwing Flatbow
+- Japan 1st Anniversary Shield
+- Japan 1st Anniversary Shield Leadership
+- Ominous Aegis
+- Ominous Aegis Leadership
+- Platinum Wand
+- Soulbreaker
+- Spiders Gluttony
+- Spiders Gluttony Leadership
+- Spiritbinder
+- Sunspear
+- Vertebreaker
+- Voltaic Wand
+- Wayward Wand
+- Zodiac Axe
+- Zodiac Daggers
+- Zodiac Longbow
+- Zodiac Shield
+- Zodiac Sword
+
+### Staff
+
+- Bo Staff
+- Dragon Staff
+- Earth Staff
+- Ghostly Staff
+- Jeweled Staff
+- Platinum Staff
+- Raven Staff
+
+### Focus
+
+- Jug
+- Paper Fan
+- Paper Lantern
+- Plagueborn Focus
+- Pronged Fan
+- Straw Effigy
+
+### Shield
+
+- Amber Aegis
+- Amethyst Aegis
+- Bladed Shield
+- Demonic Aegis
+- Draconic Aegis
+- Echovald Shield
+- Emblazoned Defender
+- Eternal Shield
+- Exalted Aegis
+- Gothic Defender
+- Guardian Of The Hunt
+- Kappa Shield
+- Magma Shield
+- Ornate Shield
+- Outcast Shield
+- Plagueborn Shield
+- Sea Purse Shield
+- Stone Summit Shield
+- Summit Warlord Shield
+- Zodiac Shield
+

--- a/lib/BotsHub-GUI.au3
+++ b/lib/BotsHub-GUI.au3
@@ -34,6 +34,7 @@ Opt('GUICloseOnESC', False)
 #include <GuiComboBox.au3>
 
 #include '../lib/JSON.au3'
+#include '../lib/Utils-Loot_Configuration.au3'
 #include '../lib/GWA2.au3'
 #include '../lib/GWA2_Assembly.au3'
 #include '../lib/GWA2_ID_Items.au3'
@@ -135,7 +136,7 @@ Global $gui_group_titles, _
 		$gui_label_lightbringertitle_text, $gui_label_lightbringertitle_value, $gui_label_sunspeartitle_text, $gui_label_sunspeartitle_value
 Global $gui_group_runoptions, _
 		$gui_checkbox_loopruns, $gui_checkbox_hardmode, $gui_checkbox_emergencytravel, $gui_checkbox_sharememory, $gui_checkbox_automaticteamsetup, $gui_checkbox_useconsumables, $gui_checkbox_useconsets, $gui_checkbox_usescrolls
-Global $gui_group_itemoptions, $gui_checkbox_sortitems, $gui_checkbox_collectdata, $gui_checkbox_salvageintocomponents, $gui_checkbox_farmmaterialsmidrun, _
+Global $gui_group_itemoptions, $gui_checkbox_sortitems, $gui_checkbox_collectdata, $gui_checkbox_farmmaterialsmidrun, _
 		$gui_label_salvagekits, $gui_combo_salvagekits, $gui_label_identificationkits, $gui_combo_identificationkits
 Global $gui_group_factionoptions, $gui_label_faction, $gui_radiobutton_donatepoints, $gui_radiobutton_buyfactionresources, $gui_radiobutton_buyfactionscrolls
 Global $gui_group_teamoptions, $gui_teamlabel, $gui_teammemberlabel, $gui_teammemberbuildlabel, _
@@ -148,6 +149,14 @@ Global $gui_group_teamoptions, $gui_teamlabel, $gui_teammemberlabel, $gui_teamme
 Global $gui_group_otheroptions, $gui_button_openstorage, $gui_checkbox_gooffline, $gui_checkbox_flashwhisper, $gui_checkbox_smartassassinspromise
 Global $gui_label_characterbuilds, $gui_label_heroesbuilds, $gui_edit_characterbuilds, $gui_edit_heroesbuilds, $gui_label_farminformations
 Global $gui_treeview_lootoptions, $gui_label_lootoptionswarning, $gui_expandlootoptionsbutton, $gui_reducelootoptionsbutton, $gui_loadlootoptionsbutton, $gui_savelootoptionsbutton, $gui_applylootoptionsbutton
+Global $gui_group_lootdecision, $gui_label_lootselection, $gui_label_lootscope, $gui_label_lootlegend, $gui_checkbox_lootignore, $gui_checkbox_lootidentify, $gui_group_lootthen, _
+		$gui_radio_lootkeep, $gui_radio_lootsalvage, $gui_radio_lootsell, $gui_radio_lootstore, $gui_checkbox_modsalvage, $gui_checkbox_modstore, $gui_checkbox_lootbuy
+; Loot tree model: decisions being edited (given to the bot with the Apply button) and tree item handles <-> configuration paths
+Global $gui_loot_decisions[]
+Global $gui_loot_paths_by_handle[]
+Global $gui_loot_handles_by_path[]
+Global $gui_loot_selected_path = ''
+Global $gui_loot_refreshing_panel = False
 
 
 ;------------------------------------------------------
@@ -156,7 +165,7 @@ Global $gui_treeview_lootoptions, $gui_label_lootoptionswarning, $gui_expandloot
 ;------------------------------------------------------
 Func CreateBotsHubGUI()
 	; -1, -1 automatically positions GUI in the middle of the screen, alternatively can do calculations with inbuilt @DesktopWidth and @DesktopHeight
-	$gui_botshub = GUICreate('GW Bot Hub', 650, 500, -1, -1)
+	$gui_botshub = GUICreate('GW Bot Hub', 900, 650, -1, -1)
 	GUISetBkColor($COLOR_SILVER, $gui_botshub)
 
 	; === Buttons common to all tabs ===
@@ -176,12 +185,12 @@ Func CreateBotsHubGUI()
 	GUICtrlSetOnEvent($gui_icon_saveconfig, 'GuiMainButtonHandler')
 
 	; === Main tab ===
-	$gui_tabs_parent = GUICtrlCreateTab(10, 10, 630, 450)
+	$gui_tabs_parent = GUICtrlCreateTab(10, 10, 880, 600)
 	$gui_tab_main = GUICtrlCreateTabItem('Main')
 	_GUICtrlTab_SetBkColor($gui_botshub, $gui_tabs_parent, $COLOR_SILVER)
 	GUICtrlSetOnEvent($gui_tabs_parent, 'GuiTabHandler')
 
-	$gui_console = _GUICtrlRichEdit_Create($gui_botshub, '', 20, 190, 300, 255, BitOR($ES_MULTILINE, $ES_READONLY, $WS_VSCROLL))
+	$gui_console = _GUICtrlRichEdit_Create($gui_botshub, '', 20, 190, 300, 400, BitOR($ES_MULTILINE, $ES_READONLY, $WS_VSCROLL))
 	_GUICtrlRichEdit_SetCharColor($gui_console, $COLOR_WHITE)
 	_GUICtrlRichEdit_SetBkColor($gui_console, $COLOR_BLACK)
 	SetConsole($gui_console)
@@ -317,7 +326,6 @@ Func CreateBotsHubGUI()
 	GUICtrlCreateGroup('', -99, -99, 1, 1)
 	$gui_group_itemoptions = GUICtrlCreateGroup('Inventory management options', 21, 205, 295, 235)
 	$gui_checkbox_sortitems = GUICtrlCreateCheckbox('Sort items', 31, 225)
-	$gui_checkbox_salvageintocomponents = GUICtrlCreateCheckbox('Salvage into components', 31, 255)
 	$gui_checkbox_farmmaterialsmidrun = GUICtrlCreateCheckbox('Salvage during run', 31, 285)
 	$gui_label_salvagekits = GUICtrlCreateLabel('Salvage kits:', 31, 318)
 	$gui_combo_salvagekits = GUICtrlCreateCombo('12', 100, 315, 40, 20, BitOR($CBS_DROPDOWNLIST, $WS_VSCROLL))
@@ -351,7 +359,6 @@ Func CreateBotsHubGUI()
 	GUICtrlSetBkColor($gui_renderbutton, $COLOR_YELLOW)
 
 	GUICtrlSetTip($gui_checkbox_farmmaterialsmidrun, 'Salvage items during runs to save space. Bot will take some salvage kits in inventory for that.')
-	GUICtrlSetTip($gui_checkbox_salvageintocomponents, 'Salvage the components ticked in Keep components (mods, inscriptions, runes, insignias) out of items not worth keeping, using expert salvage kits. Salvaged components are then stored.')
 	GUICtrlSetTip($gui_checkbox_useconsumables, 'If bot uses consumables (cake, pie, speed boosts, etc), it will do it automatically.')
 	GUICtrlSetTip($gui_checkbox_useconsets, 'If bot can use consets, it will do it automatically.')
 	GUICtrlSetTip($gui_button_openstorage, 'Open Xunlai storage window. Works remotely - view only from explorable areas.')
@@ -373,7 +380,6 @@ Func CreateBotsHubGUI()
 	GUICtrlSetOnEvent($gui_checkbox_hardmode, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_sharememory, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_farmmaterialsmidrun, 'GuiOptionsHandler')
-	GUICtrlSetOnEvent($gui_checkbox_salvageintocomponents, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_useconsumables, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_useconsets, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_usescrolls, 'GuiOptionsHandler')
@@ -500,8 +506,7 @@ Func CreateBotsHubGUI()
 
 	; === Inventory tab ===
 	$gui_tab_lootoptions = GUICtrlCreateTabItem('Inventory')
-	$gui_treeview_lootoptions = GUICtrlCreateTreeView(80, 45, 545, 400, BitOR($TVS_HASLINES, $TVS_LINESATROOT, $TVS_HASBUTTONS, $TVS_CHECKBOXES, $TVS_FULLROWSELECT))
-	BuildTreeViewFromCache($gui_treeview_lootoptions)
+	$gui_treeview_lootoptions = GUICtrlCreateTreeView(80, 45, 500, 545, BitOR($TVS_HASLINES, $TVS_LINESATROOT, $TVS_HASBUTTONS, $TVS_CHECKBOXES, $TVS_FULLROWSELECT))
 
 	$gui_expandlootoptionsbutton = GUICtrlCreateButton('Expand all', 21, 124, 55, 21)
 	$gui_reducelootoptionsbutton = GUICtrlCreateButton('Reduce all', 21, 154, 55, 21)
@@ -511,11 +516,43 @@ Func CreateBotsHubGUI()
 	$gui_applylootoptionsbutton = GUICtrlCreateButton(@LF & 'Apply' & @LF & 'changes', 21, 304, 55, 63, $BS_MULTILINE)
 	GUICtrlSetBkColor($gui_applylootoptionsbutton, $COLOR_YELLOW)
 
+	; Decision panel of the selected node - a change on a group applies to every item below it
+	$gui_group_lootdecision = GUICtrlCreateGroup('Decision', 590, 45, 285, 545)
+	$gui_label_lootselection = GUICtrlCreateLabel('Select an item or a group in the tree', 600, 65, 265, 55)
+	$gui_label_lootscope = GUICtrlCreateLabel('', 600, 122, 265, 30)
+	$gui_checkbox_lootignore = GUICtrlCreateCheckbox('Ignore: never picked up, never touched', 600, 155, 265, 20)
+	$gui_checkbox_lootidentify = GUICtrlCreateCheckbox('Identify before anything else', 600, 180, 265, 20)
+	$gui_group_lootthen = GUICtrlCreateGroup('Then', 600, 205, 265, 125)
+	$gui_radio_lootkeep = GUICtrlCreateRadio('Keep in the bags', 610, 225, 245, 20)
+	$gui_radio_lootsalvage = GUICtrlCreateRadio('Salvage', 610, 250, 245, 20)
+	$gui_radio_lootsell = GUICtrlCreateRadio('Sell', 610, 275, 245, 20)
+	$gui_radio_lootstore = GUICtrlCreateRadio('Store in the Xunlai storage', 610, 300, 245, 20)
+	GUICtrlCreateGroup('', -99, -99, 1, 1)
+	$gui_checkbox_modsalvage = GUICtrlCreateCheckbox('Salvage this mod out of items that are salvaged or sold', 600, 155, 265, 40, BitOR($BS_MULTILINE, $BS_AUTOCHECKBOX))
+	$gui_checkbox_modstore = GUICtrlCreateCheckbox('Store the salvaged mod (untick to sell it)', 600, 200, 265, 40, BitOR($BS_MULTILINE, $BS_AUTOCHECKBOX))
+	$gui_checkbox_lootbuy = GUICtrlCreateCheckbox('Buy with the spare gold', 600, 155, 265, 20)
+	$gui_label_lootlegend = GUICtrlCreateLabel('Rows show their decision in brackets, groups show [mixed] when their items differ.' & @CRLF & @CRLF & _
+		'Tree checkboxes: item picked up, mod salvaged, material bought - ticking a group ticks everything below it.' & @CRLF & @CRLF & _
+		'Weapons: rare skins with max stats have their own leaf under each requirement, the low req max stats rule replaces the leaf of such weapons, ' & _
+		'ultra rare skins and perfect old school weapons are stored instead of salvaged or sold, equipped and customized items are never touched.' & @CRLF & @CRLF & _
+		'Mods are only salvaged out of items that are salvaged or sold: stored items keep their mods.', 600, 340, 265, 245)
+	GUICtrlCreateGroup('', -99, -99, 1, 1)
+	BuildLootTreeView()
+
 	GUICtrlSetOnEvent($gui_expandlootoptionsbutton, 'GuiLootTabButtonHandler')
 	GUICtrlSetOnEvent($gui_reducelootoptionsbutton, 'GuiLootTabButtonHandler')
 	GUICtrlSetOnEvent($gui_loadlootoptionsbutton, 'GuiLootTabButtonHandler')
 	GUICtrlSetOnEvent($gui_savelootoptionsbutton, 'GuiLootTabButtonHandler')
 	GUICtrlSetOnEvent($gui_applylootoptionsbutton, 'GuiLootTabButtonHandler')
+	GUICtrlSetOnEvent($gui_checkbox_lootignore, 'GuiLootDecisionHandler')
+	GUICtrlSetOnEvent($gui_checkbox_lootidentify, 'GuiLootDecisionHandler')
+	GUICtrlSetOnEvent($gui_radio_lootkeep, 'GuiLootDecisionHandler')
+	GUICtrlSetOnEvent($gui_radio_lootsalvage, 'GuiLootDecisionHandler')
+	GUICtrlSetOnEvent($gui_radio_lootsell, 'GuiLootDecisionHandler')
+	GUICtrlSetOnEvent($gui_radio_lootstore, 'GuiLootDecisionHandler')
+	GUICtrlSetOnEvent($gui_checkbox_modsalvage, 'GuiLootDecisionHandler')
+	GUICtrlSetOnEvent($gui_checkbox_modstore, 'GuiLootDecisionHandler')
+	GUICtrlSetOnEvent($gui_checkbox_lootbuy, 'GuiLootDecisionHandler')
 	GUICtrlCreateTabItem('')
 
 	; === Infos tab ===
@@ -567,7 +604,7 @@ Func WM_COMMAND_Handler($windowHandle, $messageCode, $packedParameters, $control
 EndFunc
 
 
-;~ Handles WM_NOTIFY elements, like treeview clicks
+;~ Handles WM_NOTIFY elements: loot tree checkbox clicks, space key and selection changes
 Func WM_NOTIFY_Handler($windowHandle, $messageCode, $unusedParam, $paramNotifyStruct)
 	Local $notificationHeader = DllStructCreate('hwnd sourceHandle;int controlID;int notificationCode', $paramNotifyStruct)
 	Local $sourceHandle = DllStructGetData($notificationHeader, 'sourceHandle')
@@ -580,62 +617,26 @@ Func WM_NOTIFY_Handler($windowHandle, $messageCode, $unusedParam, $paramNotifySt
 				Local $hitTestResult = _GUICtrlTreeView_HitTestEx($sourceHandle, DllStructGetData($mousePos, 1), DllStructGetData($mousePos, 2))
 				Local $clickedItem = DllStructGetData($hitTestResult, 'Item')
 				Local $hitFlags = DllStructGetData($hitTestResult, 'Flags')
-
 				If $clickedItem <> 0 And BitAND($hitFlags, $TVHT_ONITEMSTATEICON) Then
-					ToggleCheckboxCascade($sourceHandle, $clickedItem, True)
-					ToggleCheckboxCascadeUpwards($sourceHandle, $clickedItem, True)
+					; The clicked checkbox is inverted by the tree after this handler returns, so the model gets the future state
+					; and every other node is refreshed from it
+					SetLootNodeActive(GetLootPathByHandle($clickedItem), Not _GUICtrlTreeView_GetChecked($sourceHandle, $clickedItem), $clickedItem)
 				EndIf
 
 			Case $TVN_KEYDOWN
 				Local $keyInfo = DllStructCreate('hwnd;int;int;short key;uint', $paramNotifyStruct)
 				Local $selectedItem = _GUICtrlTreeView_GetSelection($sourceHandle)
-				; Spacebar pressed
+				; Spacebar pressed: same as a click on the checkbox
 				If DllStructGetData($keyInfo, 'key') = 0x20 And $selectedItem Then
-					ToggleCheckboxCascade($sourceHandle, $selectedItem, True)
-					ToggleCheckboxCascadeUpwards($sourceHandle, $selectedItem, True)
+					SetLootNodeActive(GetLootPathByHandle($selectedItem), Not _GUICtrlTreeView_GetChecked($sourceHandle, $selectedItem), $selectedItem)
 				EndIf
+
+			Case $TVN_SELCHANGEDW, $TVN_SELCHANGEDA
+				$gui_loot_selected_path = GetLootPathByHandle(_GUICtrlTreeView_GetSelection($sourceHandle))
+				RefreshLootDecisionPanel()
 		EndSwitch
 	EndIf
 	Return $GUI_RUNDEFMSG
-EndFunc
-
-
-;~ Toggles checkbox state on a TreeView item and cascades it to children
-Func ToggleCheckboxCascade($treeViewHandle, $itemHandle, $toggleFromRoot = False)
-	Local $isChecked = _GUICtrlTreeView_GetChecked($treeViewHandle, $itemHandle)
-	; Clicked item check status is only changed after WM_NOTIFY is handled, so it needs to be inverted
-	If $toggleFromRoot Then $isChecked = Not $isChecked
-
-	If _GUICtrlTreeView_GetChildren($treeViewHandle, $itemHandle) Then
-		Local $childHandle = _GUICtrlTreeView_GetFirstChild($treeViewHandle, $itemHandle)
-		While $childHandle <> 0
-			_GUICtrlTreeView_SetChecked($treeViewHandle, $childHandle, $isChecked)
-			ToggleCheckboxCascade($treeViewHandle, $childHandle)
-			$childHandle = _GUICtrlTreeView_GetNextChild($treeViewHandle, $childHandle)
-		WEnd
-	EndIf
-EndFunc
-
-
-;~ Toggles checkbox state on a TreeView item and cascades it to its parents
-Func ToggleCheckboxCascadeUpwards($treeViewHandle, $itemHandle, $toggleFromRoot = False)
-	Local $parentHandle = _GUICtrlTreeView_GetParentHandle($treeViewHandle, $itemHandle)
-	If $parentHandle == 0 Or $parentHandle == $itemHandle Then Return
-
-	Local $allChildrenChecked = True
-	Local $childHandle = _GUICtrlTreeView_GetFirstChild($treeViewHandle, $parentHandle)
-	While $childHandle <> 0
-		Local $childChecked = _GUICtrlTreeView_GetChecked($treeViewHandle, $childHandle)
-		; Clicked item check status is only changed after WM_NOTIFY is handled, so it needs to be inverted
-		If $toggleFromRoot And $childHandle == $itemHandle Then $childChecked = Not $childChecked
-		If Not $childChecked Then
-			$allChildrenChecked = False
-			ExitLoop
-		EndIf
-		$childHandle = _GUICtrlTreeView_GetNextChild($treeViewHandle, $childHandle)
-	WEnd
-	_GUICtrlTreeView_SetChecked($treeViewHandle, $parentHandle, $allChildrenChecked)
-	ToggleCheckboxCascadeUpwards($treeViewHandle, $parentHandle)
 EndFunc
 
 
@@ -672,7 +673,7 @@ Func GuiMainButtonHandler()
 			; If run config contains a link to loot config, we need to reload loot as well
 			; We could compare old/new value or loot_configuration to see if this is worth it
 			LoadDefaultLootConfiguration()
-			BuildTreeViewFromCache($gui_treeview_lootoptions)
+			BuildLootTreeView()
 		Case $gui_icon_saveconfig
 			GUICtrlSetState($gui_icon_saveconfig, $GUI_DISABLE)
 			Local $filePath = FileSaveDialog('', @ScriptDir & '\conf\farm', '(*.json)')
@@ -733,8 +734,6 @@ Func GuiOptionsHandler()
 			$run_options_cache['run.share_memory'] = GUICtrlRead($gui_checkbox_sharememory) == $GUI_CHECKED
 		Case $gui_checkbox_farmmaterialsmidrun
 			$run_options_cache['run.farm_materials_mid_run'] = GUICtrlRead($gui_checkbox_farmmaterialsmidrun) == $GUI_CHECKED
-		Case $gui_checkbox_salvageintocomponents
-			$run_options_cache['run.salvage_into_components'] = GUICtrlRead($gui_checkbox_salvageintocomponents) == $GUI_CHECKED
 		Case $gui_checkbox_useconsumables
 			$run_options_cache['run.consume_consumables'] = GUICtrlRead($gui_checkbox_useconsumables) == $GUI_CHECKED
 		Case $gui_checkbox_useconsets
@@ -913,11 +912,10 @@ Func GuiLootTabButtonHandler()
 				Warn('Failed to read JSON loot options configuration.')
 			Else
 				LoadLootConfiguration($filePath)
-				BuildTreeViewFromCache($gui_treeview_lootoptions)
+				BuildLootTreeView()
 			EndIf
 		Case $gui_savelootoptionsbutton
-			Local $jsonObject = BuildJSONFromTreeView($gui_treeview_lootoptions)
-			Local $jsonString = _JSON_Generate($jsonObject)
+			Local $jsonString = _JSON_Generate(BuildLootJson($gui_loot_decisions))
 			Local $filePath = FileSaveDialog('', @ScriptDir & '\conf\loot', '(*.json)')
 			If @error <> 0 Then
 				Warn('Failed to write JSON loot options configuration.')
@@ -928,8 +926,7 @@ Func GuiLootTabButtonHandler()
 				Info('Saved loot options configuration ' & $filePath)
 			EndIf
 		Case $gui_applylootoptionsbutton
-			FillInventoryCacheFromTreeView($gui_treeview_lootoptions)
-			BuildInventoryDerivedFlags()
+			ApplyLootDecisions($gui_loot_decisions)
 			RefreshValuableListsFromCache()
 			Info('Refreshed inventory management options')
 		Case Else
@@ -1691,7 +1688,6 @@ Func ApplyConfigToGUI()
 	GUICtrlSetState($gui_checkbox_hardmode, $run_options_cache['run.hard_mode'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_sharememory, $run_options_cache['run.share_memory'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_farmmaterialsmidrun, $run_options_cache['run.farm_materials_mid_run'] ? $GUI_CHECKED : $GUI_UNCHECKED)
-	GUICtrlSetState($gui_checkbox_salvageintocomponents, $run_options_cache['run.salvage_into_components'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_useconsumables, $run_options_cache['run.consume_consumables'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_useconsets, $run_options_cache['run.use_consets'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_usescrolls, $run_options_cache['run.use_scrolls'] ? $GUI_CHECKED : $GUI_UNCHECKED)
@@ -1735,125 +1731,327 @@ EndFunc
 
 
 #Region Loot Tree View Management
-;~ Fill inventory cache from JSON
-Func FillInventoryCacheFromJSON($jsonNode, $currentPath)
-	If IsMap($jsonNode) Then
-		Local $checked = True
-		For $key In MapKeys($jsonNode)
-			If Not FillInventoryCacheFromJSON($jsonNode[$key], ($currentPath == '') ? $key : ($currentPath & '.' & $key)) Then $checked = False
-		Next
-		$inventory_management_cache[$currentPath] = $checked
-		Return $checked
-	Else
-		$inventory_management_cache[$currentPath] = $jsonNode
-		Return $jsonNode
-	EndIf
+;~ Handle the decision panel: the changed control is applied to the selected node, or to every item below a group
+Func GuiLootDecisionHandler()
+	If $gui_loot_refreshing_panel Then Return
+	Local $path = $gui_loot_selected_path
+	If $path == '' Then Return
+	Switch @GUI_CtrlId
+		Case $gui_checkbox_lootignore
+			ApplyLootFieldToNode($path, 'ignore', GUICtrlRead($gui_checkbox_lootignore) == $GUI_CHECKED)
+		Case $gui_checkbox_lootidentify
+			ApplyLootFieldToNode($path, 'identify', GUICtrlRead($gui_checkbox_lootidentify) == $GUI_CHECKED)
+		Case $gui_radio_lootkeep
+			ApplyLootFieldToNode($path, 'action', $LOOT_ACTION_KEEP)
+		Case $gui_radio_lootsalvage
+			ApplyLootFieldToNode($path, 'action', $LOOT_ACTION_SALVAGE)
+		Case $gui_radio_lootsell
+			ApplyLootFieldToNode($path, 'action', $LOOT_ACTION_SELL)
+		Case $gui_radio_lootstore
+			ApplyLootFieldToNode($path, 'action', $LOOT_ACTION_STORE)
+		Case $gui_checkbox_modsalvage
+			ApplyLootFieldToNode($path, 'salvage', GUICtrlRead($gui_checkbox_modsalvage) == $GUI_CHECKED)
+		Case $gui_checkbox_modstore
+			ApplyLootFieldToNode($path, 'store', GUICtrlRead($gui_checkbox_modstore) == $GUI_CHECKED)
+		Case $gui_checkbox_lootbuy
+			ApplyLootFieldToNode($path, 'buy', GUICtrlRead($gui_checkbox_lootbuy) == $GUI_CHECKED)
+	EndSwitch
+	RefreshLootTreeBranch($path)
+	RefreshLootDecisionPanel()
 EndFunc
 
 
-;~ Build TreeView from flat map
-Func BuildTreeViewFromCache($guiTreeviewHandle)
-	_GUICtrlTreeView_DeleteAll($guiTreeviewHandle)
-	Local $mapTreeViewIDs[]
-	For $key In MapKeys($inventory_management_cache)
-		; Parent item, no need to draw it
-		If $key == '' Then ContinueLoop
-		; Derived value, does not show in interface
-		If StringLeft($key, 1) == '@' Then ContinueLoop
+;~ Rebuild the loot tree from the loaded configuration: one node per group and per leaf, decisions shown in brackets
+;~ The tree edits a copy of the decisions, applied to the bot with the Apply button
+Func BuildLootTreeView()
+	Local $treeHandle = GUICtrlGetHandle($gui_treeview_lootoptions)
+	_GUICtrlTreeView_BeginUpdate($treeHandle)
+	_GUICtrlTreeView_DeleteAll($treeHandle)
+	$gui_loot_decisions = $loot_decisions
+	Local $emptyPaths[]
+	Local $emptyHandles[]
+	$gui_loot_paths_by_handle = $emptyPaths
+	$gui_loot_handles_by_path = $emptyHandles
+	$gui_loot_selected_path = ''
 
-		Local $bananaSplit = StringSplit($key, '.')
-		Local $current = Null
+	Local $controlIDs[]
+	For $path In MapKeys($gui_loot_decisions)
+		Local $parts = StringSplit($path, '.')
+		Local $parentID = Null
 		Local $currentPath = ''
-		For $i = 1 To $bananaSplit[0]
-			Local $part = $bananaSplit[$i]
-			$currentPath &= ($currentPath == '') ? $part : ('.' & $part)
-			If $mapTreeViewIDs[$currentPath] <> Null Then
-				; Already exists in map
-				$current = $mapTreeViewIDs[$currentPath]
+		For $i = 1 To $parts[0]
+			$currentPath &= ($i == 1 ? '' : '.') & $parts[$i]
+			If MapExists($controlIDs, $currentPath) Then
+				$parentID = $controlIDs[$currentPath]
+				ContinueLoop
+			EndIf
+			Local $controlID = GUICtrlCreateTreeViewItem($parts[$i], $parentID == Null ? $gui_treeview_lootoptions : $parentID)
+			$controlIDs[$currentPath] = $controlID
+			Local $handle = GUICtrlGetHandle($controlID)
+			$gui_loot_paths_by_handle[Int($handle)] = $currentPath
+			$gui_loot_handles_by_path[$currentPath] = $handle
+			$parentID = $controlID
+		Next
+	Next
+	Local $summaries = ComputeLootSummaries()
+	For $path In MapKeys($gui_loot_handles_by_path)
+		RefreshLootTreeNode($path, $summaries, 0)
+	Next
+	_GUICtrlTreeView_EndUpdate($treeHandle)
+	RefreshLootDecisionPanel()
+EndFunc
+
+
+;~ Path of a tree item from its handle, empty when unknown
+Func GetLootPathByHandle($handle)
+	If $handle == 0 Or $handle == Null Then Return ''
+	Local $key = Int($handle)
+	If Not MapExists($gui_loot_paths_by_handle, $key) Then Return ''
+	Return $gui_loot_paths_by_handle[$key]
+EndFunc
+
+
+;~ Text shown in brackets after a node name for a decision
+Func FormatLootDecisionText($path, $decision)
+	Switch GetLootNodeKind($path)
+		Case $LOOT_KIND_ITEM
+			Local $parsed = ParseItemDecision($decision)
+			If $parsed['ignore'] Then Return 'Ignore'
+			Local $text = ''
+			If $parsed['identify'] Then $text = 'Identify, '
+			Switch $parsed['action']
+				Case $LOOT_ACTION_SALVAGE
+					Return $text & 'Salvage'
+				Case $LOOT_ACTION_SELL
+					Return $text & 'Sell'
+				Case $LOOT_ACTION_STORE
+					Return $text & 'Store'
+			EndSwitch
+			Return $text & 'Keep'
+		Case $LOOT_KIND_MOD
+			Local $parsed = ParseModDecision($decision)
+			If Not $parsed['salvage'] Then Return 'Leave on item'
+			Return $parsed['store'] ? 'Salvage, store' : 'Salvage, sell'
+		Case $LOOT_KIND_BUY
+			Return $decision == True ? 'Buy' : 'Do not buy'
+	EndSwitch
+	Return ''
+EndFunc
+
+
+;~ Summaries of every leaf and group of the edited decisions: text in brackets, tree checkbox state and number of items
+;~ A group shows the common decision of its items, or 'mixed', and is checked when every item below it is active
+Func ComputeLootSummaries()
+	Local $summaries[]
+	For $path In MapKeys($gui_loot_decisions)
+		Local $decision = $gui_loot_decisions[$path]
+		Local $text = FormatLootDecisionText($path, $decision)
+		Local $active = IsLootDecisionActive($path, $decision)
+		Local $leaf[]
+		$leaf['text'] = $text
+		$leaf['active'] = $active
+		$leaf['count'] = 1
+		$summaries[$path] = $leaf
+		Local $parts = StringSplit($path, '.')
+		Local $current = ''
+		For $i = 1 To $parts[0] - 1
+			$current &= ($i == 1 ? '' : '.') & $parts[$i]
+			If MapExists($summaries, $current) Then
+				Local $existing = $summaries[$current]
+				If $existing['text'] <> $text Then $existing['text'] = 'mixed'
+				If Not $active Then $existing['active'] = False
+				$existing['count'] = $existing['count'] + 1
+				$summaries[$current] = $existing
 			Else
-				; Does not exist yet, create and add to map
-				$current = GUICtrlCreateTreeViewItem($part, $current <> Null ? $current : $guiTreeviewHandle)
-				$mapTreeViewIDs[$currentPath] = $current
+				Local $created[]
+				$created['text'] = $text
+				$created['active'] = $active
+				$created['count'] = 1
+				$summaries[$current] = $created
 			EndIf
 		Next
-		_GUICtrlTreeView_SetChecked($guiTreeviewHandle, $current, $inventory_management_cache[$key])
+	Next
+	Return $summaries
+EndFunc
+
+
+;~ Refresh the text and checkbox of one node from the summaries - the node whose checkbox is being toggled by the tree keeps its state
+Func RefreshLootTreeNode($path, $summaries, $skipCheckHandle)
+	If Not MapExists($gui_loot_handles_by_path, $path) Then Return
+	If Not MapExists($summaries, $path) Then Return
+	Local $treeHandle = GUICtrlGetHandle($gui_treeview_lootoptions)
+	Local $handle = $gui_loot_handles_by_path[$path]
+	Local $summary = $summaries[$path]
+	Local $name = $path
+	Local $lastDot = StringInStr($path, '.', 0, -1)
+	If $lastDot > 0 Then $name = StringTrimLeft($path, $lastDot)
+	_GUICtrlTreeView_SetText($treeHandle, $handle, $name & '  [' & $summary['text'] & ']')
+	If $skipCheckHandle <> 0 And Int($handle) == Int($skipCheckHandle) Then Return
+	_GUICtrlTreeView_SetChecked($treeHandle, $handle, $summary['active'])
+EndFunc
+
+
+;~ Refresh a node, everything below it and its ancestors after a change
+Func RefreshLootTreeBranch($path, $skipCheckHandle = 0)
+	Local $summaries = ComputeLootSummaries()
+	Local $prefix = $path & '.'
+	For $nodePath In MapKeys($gui_loot_handles_by_path)
+		If $nodePath == $path Or StringLeft($nodePath, StringLen($prefix)) == $prefix Then RefreshLootTreeNode($nodePath, $summaries, $skipCheckHandle)
+	Next
+	Local $parts = StringSplit($path, '.')
+	Local $current = ''
+	For $i = 1 To $parts[0] - 1
+		$current &= ($i == 1 ? '' : '.') & $parts[$i]
+		RefreshLootTreeNode($current, $summaries, $skipCheckHandle)
 	Next
 EndFunc
 
 
-;~ Fill the inventory cache with the treeview data
-Func FillInventoryCacheFromTreeView($treeViewHandle)
-	IterateOverTreeView(Null, $treeViewHandle, Null, '', AddToInventoryCache)
+;~ Tree checkbox toggled on a node: items are picked up or ignored, mods salvaged or left, buy items bought or not
+Func SetLootNodeActive($path, $active, $toggledHandle = 0)
+	If $path == '' Then Return
+	Switch GetLootNodeKind($path)
+		Case $LOOT_KIND_ITEM
+			ApplyLootFieldToNode($path, 'ignore', Not $active)
+		Case $LOOT_KIND_MOD
+			ApplyLootFieldToNode($path, 'salvage', $active)
+		Case $LOOT_KIND_BUY
+			ApplyLootFieldToNode($path, 'buy', $active)
+	EndSwitch
+	RefreshLootTreeBranch($path, $toggledHandle)
+	If $path == $gui_loot_selected_path Then RefreshLootDecisionPanel()
 EndFunc
 
 
-;~ Utility function to add treeview elements to the inventory cache
-Func AddToInventoryCache(ByRef $context, $treeViewHandle, $treeViewItem, $currentPath)
-	$inventory_management_cache[$currentPath] = _GUICtrlTreeView_GetChecked($treeViewHandle, $treeViewItem)
-EndFunc
-
-
-;~ Creating a JSON node from a treeview
-Func BuildJSONFromTreeView($treeViewHandle, $treeViewItem = Null, $currentPath = '')
-	Local $jsonObject
-	IterateOverTreeView($jsonObject, $treeViewHandle, $treeViewItem, $currentPath, AddLeavesToJSONObject)
-	Return $jsonObject
-EndFunc
-
-
-;~ Utility function to add treeview elements to a JSON object
-Func AddLeavesToJSONObject(ByRef $context, $treeViewHandle, $treeViewItem, $currentPath)
-	; We are on a leaf
-	If _GUICtrlTreeView_GetChildCount($treeViewHandle, $treeViewItem) <= 0 Then
-		_JSON_addChangeDelete($context, $currentPath, _GUICtrlTreeView_GetChecked($treeViewHandle, $treeViewItem))
-	EndIf
-EndFunc
-
-
-;~ Creating an array from a treeview
-Func BuildArrayFromTreeView($treeViewHandle, $treeViewItem = Null, $currentPath = '', $recursive = True)
-	Local $array[0]
-	IterateOverTreeView($array, $treeViewHandle, $treeViewItem, $currentPath, AddLeafToArray, $recursive ? -1 : 2)
-	Return $array
-EndFunc
-
-
-;~ Utility function to add treeview elements to an array
-Func AddLeafToArray(ByRef $context, $treeViewHandle, $treeViewItem, $currentPath)
-	; We are on a leaf
-	If _GUICtrlTreeView_GetChildCount($treeViewHandle, $treeViewItem) <= 0 Then
-		If _GUICtrlTreeView_GetChecked($treeViewHandle, $treeViewItem) Then _ArrayAdd($context, $currentPath)
-	EndIf
-EndFunc
-
-
-;~ Iterate over a treeview and make an operation on every node - can be called on root node (Null) or any other node
-Func IterateOverTreeView(ByRef $context, $treeViewHandle, $treeViewItem = Null, $currentPath = '', $functionToApply = Null, $maxDepth = -1)
-	If $treeViewItem == Null Then
-		$treeViewItem = _GUICtrlTreeView_GetFirstItem($treeViewHandle)
-		While $treeViewItem <> 0
-			IterateOverTreeItem($context, $treeViewHandle, $treeViewItem, $currentPath, $functionToApply, 1, $maxDepth)
-			$treeViewItem = _GUICtrlTreeView_GetNextSibling($treeViewHandle, $treeViewItem)
-		WEnd
+;~ Apply one decision field to a leaf, or to every leaf below a group
+Func ApplyLootFieldToNode($path, $field, $value)
+	If MapExists($gui_loot_decisions, $path) Then
+		SetLootLeafField($path, $field, $value)
 		Return
 	EndIf
-	IterateOverTreeItem($context, $treeViewHandle, $treeViewItem, $currentPath, $functionToApply, 1, $maxDepth)
+	Local $prefix = $path & '.'
+	For $leafPath In MapKeys($gui_loot_decisions)
+		If StringLeft($leafPath, StringLen($prefix)) == $prefix Then SetLootLeafField($leafPath, $field, $value)
+	Next
 EndFunc
 
 
-;~ Iterate over a treeview item and make an operation on every node - cannot be called on root node (Null)
-Func IterateOverTreeItem(ByRef $context, $treeViewHandle, $treeViewItem, $currentPath, $functionToApply, $currentDepth, $maxDepth)
-	If $maxDepth <> -1 And $currentDepth > $maxDepth Then Return
-	Local $treeViewItemName = _GUICtrlTreeView_GetText($treeViewHandle, $treeViewItem)
-	Local $newPath = ($currentPath == '') ? $treeViewItemName : $currentPath & '.' & $treeViewItemName
-	If $functionToApply <> Null Then $functionToApply($context, $treeViewHandle, $treeViewItem, $newPath)
-
-	Local $child = _GUICtrlTreeView_GetFirstChild($treeViewHandle, $treeViewItem)
-	While $child <> 0
-		IterateOverTreeItem($context, $treeViewHandle, $child, $newPath, $functionToApply, $currentDepth + 1, $maxDepth)
-		$child = _GUICtrlTreeView_GetNextSibling($treeViewHandle, $child)
-	WEnd
+;~ Change one field of a leaf decision - ignore blocks the other item fields, salvage blocks the store field of mods
+Func SetLootLeafField($path, $field, $value)
+	Switch GetLootNodeKind($path)
+		Case $LOOT_KIND_ITEM
+			Local $decision = ParseItemDecision($gui_loot_decisions[$path])
+			Switch $field
+				Case 'ignore'
+					$decision['ignore'] = $value
+				Case 'identify'
+					If $decision['ignore'] Then Return
+					$decision['identify'] = $value
+				Case 'action'
+					If $decision['ignore'] Then Return
+					$decision['action'] = $value
+			EndSwitch
+			$gui_loot_decisions[$path] = FormatItemDecision($decision['ignore'], $decision['identify'], $decision['action'])
+		Case $LOOT_KIND_MOD
+			Local $decision = ParseModDecision($gui_loot_decisions[$path])
+			Switch $field
+				Case 'salvage'
+					; A mod that starts being salvaged is stored until told otherwise
+					If $value And Not $decision['salvage'] Then $decision['store'] = True
+					$decision['salvage'] = $value
+				Case 'store'
+					If Not $decision['salvage'] Then Return
+					$decision['store'] = $value
+			EndSwitch
+			$gui_loot_decisions[$path] = FormatModDecision($decision['salvage'], $decision['store'])
+		Case $LOOT_KIND_BUY
+			If $field == 'buy' Then $gui_loot_decisions[$path] = ($value == True)
+	EndSwitch
 EndFunc
+
+
+;~ Decision of a leaf, or of the first leaf below a group - Null when there is none
+Func GetLootRepresentativeDecision($path)
+	If MapExists($gui_loot_decisions, $path) Then Return $gui_loot_decisions[$path]
+	Local $prefix = $path & '.'
+	For $leafPath In MapKeys($gui_loot_decisions)
+		If StringLeft($leafPath, StringLen($prefix)) == $prefix Then Return $gui_loot_decisions[$leafPath]
+	Next
+	Return Null
+EndFunc
+
+
+;~ Show or hide the decision panel controls of one kind of node
+Func ShowLootPanelControls($kind)
+	Local $itemControls = [$gui_checkbox_lootignore, $gui_checkbox_lootidentify, $gui_group_lootthen, $gui_radio_lootkeep, $gui_radio_lootsalvage, $gui_radio_lootsell, $gui_radio_lootstore]
+	Local $modControls = [$gui_checkbox_modsalvage, $gui_checkbox_modstore]
+	Local $buyControls = [$gui_checkbox_lootbuy]
+	For $control In $itemControls
+		GUICtrlSetState($control, $kind == $LOOT_KIND_ITEM ? $GUI_SHOW : $GUI_HIDE)
+	Next
+	For $control In $modControls
+		GUICtrlSetState($control, $kind == $LOOT_KIND_MOD ? $GUI_SHOW : $GUI_HIDE)
+	Next
+	For $control In $buyControls
+		GUICtrlSetState($control, $kind == $LOOT_KIND_BUY ? $GUI_SHOW : $GUI_HIDE)
+	Next
+EndFunc
+
+
+;~ Show the decision of the selected node in the panel - a group shows the decision shared by its items, nothing when they differ
+Func RefreshLootDecisionPanel()
+	$gui_loot_refreshing_panel = True
+	Local $path = $gui_loot_selected_path
+	Local $kind = GetLootNodeKind($path)
+	If $path == '' Or $kind == '' Then
+		GUICtrlSetData($gui_label_lootselection, 'Select an item or a group in the tree')
+		GUICtrlSetData($gui_label_lootscope, '')
+		ShowLootPanelControls('')
+		$gui_loot_refreshing_panel = False
+		Return
+	EndIf
+	Local $summaries = ComputeLootSummaries()
+	Local $summary = $summaries[$path]
+	Local $isLeaf = MapExists($gui_loot_decisions, $path)
+	Local $mixed = Not $isLeaf And $summary['text'] == 'mixed'
+	GUICtrlSetData($gui_label_lootselection, StringReplace($path, '.', ' > '))
+	If $isLeaf Then
+		GUICtrlSetData($gui_label_lootscope, '')
+	ElseIf $mixed Then
+		GUICtrlSetData($gui_label_lootscope, 'Group of ' & $summary['count'] & ' items with different decisions - a change applies to all of them')
+	Else
+		GUICtrlSetData($gui_label_lootscope, 'Group of ' & $summary['count'] & ' items - a change applies to all of them')
+	EndIf
+	ShowLootPanelControls($kind)
+
+	Local $decision = GetLootRepresentativeDecision($path)
+	Switch $kind
+		Case $LOOT_KIND_ITEM
+			Local $parsed = ParseItemDecision($mixed Or $decision == Null ? $LOOT_ACTION_KEEP : $decision)
+			Local $ignore = Not $mixed And $parsed['ignore']
+			GUICtrlSetState($gui_checkbox_lootignore, $ignore ? $GUI_CHECKED : $GUI_UNCHECKED)
+			GUICtrlSetState($gui_checkbox_lootidentify, (Not $mixed And $parsed['identify']) ? $GUI_CHECKED : $GUI_UNCHECKED)
+			GUICtrlSetState($gui_radio_lootkeep, (Not $mixed And Not $ignore And $parsed['action'] == $LOOT_ACTION_KEEP) ? $GUI_CHECKED : $GUI_UNCHECKED)
+			GUICtrlSetState($gui_radio_lootsalvage, (Not $mixed And Not $ignore And $parsed['action'] == $LOOT_ACTION_SALVAGE) ? $GUI_CHECKED : $GUI_UNCHECKED)
+			GUICtrlSetState($gui_radio_lootsell, (Not $mixed And Not $ignore And $parsed['action'] == $LOOT_ACTION_SELL) ? $GUI_CHECKED : $GUI_UNCHECKED)
+			GUICtrlSetState($gui_radio_lootstore, (Not $mixed And Not $ignore And $parsed['action'] == $LOOT_ACTION_STORE) ? $GUI_CHECKED : $GUI_UNCHECKED)
+			; Ignore blocks the other options
+			Local $otherControls = [$gui_checkbox_lootidentify, $gui_radio_lootkeep, $gui_radio_lootsalvage, $gui_radio_lootsell, $gui_radio_lootstore]
+			For $control In $otherControls
+				GUICtrlSetState($control, $ignore ? $GUI_DISABLE : $GUI_ENABLE)
+			Next
+		Case $LOOT_KIND_MOD
+			Local $parsed = ParseModDecision($mixed Or $decision == Null ? $LOOT_DECISION_IGNORE : $decision)
+			GUICtrlSetState($gui_checkbox_modsalvage, $parsed['salvage'] ? $GUI_CHECKED : $GUI_UNCHECKED)
+			GUICtrlSetState($gui_checkbox_modstore, $parsed['store'] ? $GUI_CHECKED : $GUI_UNCHECKED)
+			GUICtrlSetState($gui_checkbox_modstore, $parsed['salvage'] ? $GUI_ENABLE : $GUI_DISABLE)
+		Case $LOOT_KIND_BUY
+			GUICtrlSetState($gui_checkbox_lootbuy, (Not $mixed And $decision == True) ? $GUI_CHECKED : $GUI_UNCHECKED)
+	EndSwitch
+	$gui_loot_refreshing_panel = False
+EndFunc
+
+
 #EndRegion Loot Tree View Management
 
 
@@ -1927,104 +2125,4 @@ Func TemporaryGUIWMActivateHandler($handle, $message, $param)
 EndFunc
 
 
-;~ Getting ticked loot options from checkboxes as array
-Func GetLootOptionsTickedCheckboxes($startingPoint, $treeViewHandle = $gui_treeview_lootoptions, $pathDelimiter = '.', $recursive = True)
-	Local $treeViewItem = FindNodeInTreeView($treeViewHandle, Null, $startingPoint, $pathDelimiter)
-	Return $treeViewItem == Null ? Null : BuildArrayFromTreeView($treeViewHandle, $treeViewItem, '', $recursive)
-EndFunc
-
-
-;~ Find a node in a treeview by its path as string
-Func FindNodeInTreeView($treeViewHandle, $treeViewItem = Null, $path = '', $pathDelimiter = '.')
-	Local $pathArray = StringSplit($path, $pathDelimiter)
-	; Caution in AutoIT, StringSplit function returns array in which first element is count of items
-	Local $pathArraySize = $pathArray[0]
-	If $pathArraySize == 0 Or $path == '' Then Return Null
-	If $treeViewItem == Null Then $treeViewItem = _GUICtrlTreeView_GetFirstItem($treeViewHandle)
-	Return FindNodeInTreeViewHelper($treeViewHandle, $treeViewItem, $pathArray, 1)
-EndFunc
-
-
-;~ Find a node in a treeview by its path as string
-Func FindNodeInTreeViewHelper($treeViewHandle, $treeViewItem, $pathArray, $pathArrayIndex)
-	Local $treeViewItemName, $treeViewItemChildCount, $treeViewItemFirstChild
-	While $treeViewItem <> 0
-		$treeViewItemName = _GUICtrlTreeView_GetText($treeViewHandle, $treeViewItem)
-		$treeViewItemChildCount = _GUICtrlTreeView_GetChildCount($treeViewHandle, $treeViewItem)
-		If $treeViewItemName == $pathArray[$pathArrayIndex] Then
-			If $pathArrayIndex == UBound($pathArray) - 1 Then
-				Return $treeViewItem
-			Else
-				Return FindNodeInTreeViewHelper($treeViewHandle, _GUICtrlTreeView_GetFirstChild($treeViewHandle, $treeViewItem), $pathArray, $pathArrayIndex + 1)
-			EndIf
-		EndIf
-		$treeViewItem = _GUICtrlTreeView_GetNextSibling($treeViewHandle, $treeViewItem)
-	WEnd
-	Return Null
-EndFunc
-
-
-;~ Find the child from the given treeview by its name
-Func FindDirectChildTreeViewItem($treeViewHandle, $treeViewItem, $name)
-	If $treeViewItem == Null Then
-		$treeViewItem = _GUICtrlTreeView_GetFirstItem($treeViewHandle)
-	EndIf
-	Return FindDirectChildTreeViewItemHelper($treeViewHandle, $treeViewItem, $name)
-EndFunc
-
-
-;~ Find a node in a treeview by its path as string
-Func FindDirectChildTreeViewItemHelper($treeViewHandle, $treeViewItem, $name)
-	Local $treeViewItemName
-	While $treeViewItem <> 0
-		$treeViewItemName = _GUICtrlTreeView_GetText($treeViewHandle, $treeViewItem)
-		If $treeViewItemName == $name Then
-			Return $treeViewItem
-		EndIf
-		$treeViewItem = _GUICtrlTreeView_GetNextSibling($treeViewHandle, $treeViewItem)
-	WEnd
-	Return Null
-EndFunc
-
-
-;~ Creating a treeview from a JSON node
-Func BuildTreeViewFromJSON($parentItem, $jsonNode)
-	If IsMap($jsonNode) Then
-		Local $isChecked = True
-		For $key In MapKeys($jsonNode)
-			Local $keyHandle = GUICtrlCreateTreeViewItem($key, $parentItem)
-			If Not BuildTreeViewFromJSON($keyHandle, $jsonNode[$key]) Then $isChecked = False
-		Next
-		_GUICtrlTreeView_SetChecked($gui_treeview_lootoptions, $parentItem, $isChecked)
-		Return $isChecked
-	EndIf
-	; Leaf node: this node is true or false
-	_GUICtrlTreeView_SetChecked($gui_treeview_lootoptions, $parentItem, $jsonNode)
-	Return $jsonNode == True
-EndFunc
-
-
-;~ Function to recursively traverse a branch in a tree view to check if any child in that branch is checked
-Func IsAnyChildInBranchChecked($treeViewHandle, $treeViewItem)
-	; Check if current tree node item is checked
-	If _GUICtrlTreeView_GetChecked($treeViewHandle, $treeViewItem) Then Return True
-
-	; Recursively check all child items of provided $treeViewItem
-	If _GUICtrlTreeView_GetChildren($treeViewHandle, $treeViewItem) Then
-		Local $childHandle = _GUICtrlTreeView_GetFirstChild($treeViewHandle, $treeViewItem)
-		While $childHandle <> 0
-			If IsAnyChildInBranchChecked($treeViewHandle, $childHandle) Then Return True
-			$childHandle = _GUICtrlTreeView_GetNextChild($treeViewHandle, $childHandle)
-		WEnd
-	EndIf
-
-	Return False
-EndFunc
-
-
-;~ Function to check if any checkbox is checked in a branch starting in node provided as path string
-Func IsAnyLootOptionInBranchChecked($startNodePath, $treeViewHandle = $gui_treeview_lootoptions, $pathDelimiter = '.')
-	Local $treeViewItem = FindNodeInTreeView($treeViewHandle, Null, $startNodePath, $pathDelimiter)
-	Return $treeViewItem == Null ? False : IsAnyChildInBranchChecked($treeViewHandle, $treeViewItem)
-EndFunc
 #EndRegion Dead GUI code but keep because it could come handy

--- a/lib/BotsHub-GUI.au3
+++ b/lib/BotsHub-GUI.au3
@@ -169,12 +169,12 @@ Func CreateBotsHubGUI()
 	GUISetBkColor($COLOR_SILVER, $gui_botshub)
 
 	; === Buttons common to all tabs ===
-	$gui_combo_characterchoice = GUICtrlCreateCombo('No character selected', 10, 470, 150, 20)
-	$gui_combo_farmchoice = GUICtrlCreateCombo('Choose a farm', 170, 470, 150, 20, BitOR($CBS_DROPDOWN, $WS_VSCROLL))
-	$gui_startbutton = GUICtrlCreateButton('Start', 330, 470, 150, 21)
-	$gui_farmprogress = GUICtrlCreateProgress(490, 470, 150, 21)
-	$gui_combo_configchoice = GUICtrlCreateCombo('Default Farm Configuration', 400, 10, 210, 22, BitOR($CBS_DROPDOWNLIST, $WS_VSCROLL))
-	$gui_icon_saveconfig = GUICtrlCreatePic(@ScriptDir & '/doc/save.jpg', 615, 12, 20, 20)
+	$gui_combo_characterchoice = GUICtrlCreateCombo('No character selected', 10, 620, 210, 20)
+	$gui_combo_farmchoice = GUICtrlCreateCombo('Choose a farm', 230, 620, 210, 20, BitOR($CBS_DROPDOWN, $WS_VSCROLL))
+	$gui_startbutton = GUICtrlCreateButton('Start', 450, 620, 210, 21)
+	$gui_farmprogress = GUICtrlCreateProgress(670, 620, 220, 21)
+	$gui_combo_configchoice = GUICtrlCreateCombo('Default Farm Configuration', 650, 10, 210, 22, BitOR($CBS_DROPDOWNLIST, $WS_VSCROLL))
+	$gui_icon_saveconfig = GUICtrlCreatePic(@ScriptDir & '/doc/save.jpg', 865, 12, 20, 20)
 	GUICtrlSetData($gui_combo_farmchoice, $AVAILABLE_FARMS, 'Choose a farm')
 	GUICtrlSetBkColor($gui_startbutton, $COLOR_LIGHTBLUE)
 
@@ -533,7 +533,7 @@ Func CreateBotsHubGUI()
 	$gui_checkbox_lootbuy = GUICtrlCreateCheckbox('Buy with the spare gold', 600, 155, 265, 20)
 	$gui_label_lootlegend = GUICtrlCreateLabel('Rows show their decision in brackets, groups show [mixed] when their items differ.' & @CRLF & @CRLF & _
 		'Tree checkboxes: item picked up, mod salvaged, material bought - ticking a group ticks everything below it.' & @CRLF & @CRLF & _
-		'Weapons: rare skins with max stats have their own leaf under each requirement, the low req max stats rule replaces the leaf of such weapons, ' & _
+		'Weapons: rare skins with max stats (lists in doc/rare-skins.md) have their own leaf under each requirement, the low req max stats rule replaces the leaf of such weapons, ' & _
 		'ultra rare skins and perfect old school weapons are stored instead of salvaged or sold, equipped and customized items are never touched.' & @CRLF & @CRLF & _
 		'Mods are only salvaged out of items that are salvaged or sold: stored items keep their mods.', 600, 340, 265, 245)
 	GUICtrlCreateGroup('', -99, -99, 1, 1)

--- a/lib/BotsHub-GUI.au3
+++ b/lib/BotsHub-GUI.au3
@@ -145,7 +145,7 @@ Global $gui_group_teamoptions, $gui_teamlabel, $gui_teammemberlabel, $gui_teamme
 		$gui_checkbox_load_build_hero_4, $gui_checkbox_load_build_hero_5, $gui_checkbox_load_build_hero_6, $gui_checkbox_load_build_hero_7, _
 		$gui_label_build_hero_1, $gui_label_build_hero_2, $gui_label_build_hero_3, $gui_label_build_hero_4, $gui_label_build_hero_5, $gui_label_build_hero_6, $gui_label_build_hero_7, _
 		$gui_input_build_player, $gui_input_build_hero_1, $gui_input_build_hero_2, $gui_input_build_hero_3, $gui_input_build_hero_4, $gui_input_build_hero_5, $gui_input_build_hero_6, $gui_input_build_hero_7
-Global $gui_group_otheroptions, $gui_button_openstorage, $gui_checkbox_gooffline, $gui_checkbox_flashwhisper
+Global $gui_group_otheroptions, $gui_button_openstorage, $gui_checkbox_gooffline, $gui_checkbox_flashwhisper, $gui_checkbox_smartassassinspromise
 Global $gui_label_characterbuilds, $gui_label_heroesbuilds, $gui_edit_characterbuilds, $gui_edit_heroesbuilds, $gui_label_farminformations
 Global $gui_treeview_lootoptions, $gui_label_lootoptionswarning, $gui_expandlootoptionsbutton, $gui_reducelootoptionsbutton, $gui_loadlootoptionsbutton, $gui_savelootoptionsbutton, $gui_applylootoptionsbutton
 
@@ -413,6 +413,9 @@ Func CreateBotsHubGUI()
 		'- correct behaviour (passive/aggressive)' & @CRLF & _
 		'If party size is 4 or 6, last heroes just will not be added to party.', 40, 70)
 	$gui_checkbox_automaticteamsetup = GUICtrlCreateCheckbox('Setup team automatically using team options section', 31, 140)
+	$gui_checkbox_smartassassinspromise = GUICtrlCreateCheckbox('Smart Assassin''s Promise casting', 375, 140)
+	GUICtrlSetTip($gui_checkbox_smartassassinspromise, 'When Assassin''s Promise is on the player skillbar, fights use a build-aware casting routine: Promise once the target nears 50% health, "Finish Him!" under 50%, "You Move Like a Dwarf!" to finish, Ebon Vanguard Assassin Support otherwise, mesmer Arcane Echo and Auspicious Incantation only where they pay off. Untick to cast skills from 1 to 8 instead.')
+	GUICtrlSetOnEvent($gui_checkbox_smartassassinspromise, 'GuiOptionsHandler')
 	$gui_teammemberlabel = GUICtrlCreateLabel('Team member', 147, 170, 100, 20)
 	$gui_teammemberbuildlabel = GUICtrlCreateLabel('Team member build', 445, 170, 100, 20)
 	$gui_checkbox_load_build_all = GUICtrlCreateCheckbox('Load all builds:', 254, 167)
@@ -739,6 +742,8 @@ Func GuiOptionsHandler()
 			$run_options_cache['run.go_offline'] = GUICtrlRead($gui_checkbox_gooffline) == $GUI_CHECKED
 		Case $gui_checkbox_flashwhisper
 			$run_options_cache['run.flash_whisper'] = GUICtrlRead($gui_checkbox_flashwhisper) == $GUI_CHECKED
+		Case $gui_checkbox_smartassassinspromise
+			$run_options_cache['run.smart_assassins_promise'] = GUICtrlRead($gui_checkbox_smartassassinspromise) == $GUI_CHECKED
 		Case $gui_checkbox_sortitems
 			$run_options_cache['run.sort_items'] = GUICtrlRead($gui_checkbox_sortitems) == $GUI_CHECKED
 		Case $gui_checkbox_collectdata
@@ -936,7 +941,7 @@ Func UpdateFarmDescription($farm)
 	GUICtrlSetData($gui_edit_heroesbuilds, '')
 	GUICtrlSetData($gui_label_farminformations, '')
 
-	Local $generalCharacterSetup = 'Simple build to play from skill 1 to skill 8, such as:' & @CRLF & _
+	Local $generalCharacterSetup = 'Assassin''s Promise builds are played with a dedicated casting routine (see the Team tab option), other builds from skill 1 to skill 8. Suggested builds:' & @CRLF & _
 		'https://gwpvx.fandom.com/wiki/Build:N/A_Assassin%27s_Promise_Death_Magic' & @CRLF & _
 		'https://gwpvx.fandom.com/wiki/Build:E/A_Assassin%27s_Promise' & @CRLF & _
 		'https://gwpvx.fandom.com/wiki/Build:Me/A_Assassin%27s_Promise'
@@ -1688,6 +1693,7 @@ Func ApplyConfigToGUI()
 	GUICtrlSetState($gui_checkbox_usescrolls, $run_options_cache['run.use_scrolls'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_gooffline, $run_options_cache['run.go_offline'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_flashwhisper, $run_options_cache['run.flash_whisper'] ? $GUI_CHECKED : $GUI_UNCHECKED)
+	GUICtrlSetState($gui_checkbox_smartassassinspromise, $run_options_cache['run.smart_assassins_promise'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_sortitems, $run_options_cache['run.sort_items'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_collectdata, $run_options_cache['run.collect_data'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_radiobutton_donatepoints, $run_options_cache['run.donate_faction_points'] ? $GUI_CHECKED : $GUI_UNCHECKED)

--- a/lib/BotsHub-GUI.au3
+++ b/lib/BotsHub-GUI.au3
@@ -318,7 +318,6 @@ Func CreateBotsHubGUI()
 	$gui_group_itemoptions = GUICtrlCreateGroup('Inventory management options', 21, 205, 295, 235)
 	$gui_checkbox_sortitems = GUICtrlCreateCheckbox('Sort items', 31, 225)
 	$gui_checkbox_salvageintocomponents = GUICtrlCreateCheckbox('Salvage into components', 31, 255)
-	GUICtrlSetState($gui_checkbox_salvageintocomponents, $GUI_DISABLE)
 	$gui_checkbox_farmmaterialsmidrun = GUICtrlCreateCheckbox('Salvage during run', 31, 285)
 	$gui_label_salvagekits = GUICtrlCreateLabel('Salvage kits:', 31, 318)
 	$gui_combo_salvagekits = GUICtrlCreateCombo('12', 100, 315, 40, 20, BitOR($CBS_DROPDOWNLIST, $WS_VSCROLL))
@@ -352,6 +351,7 @@ Func CreateBotsHubGUI()
 	GUICtrlSetBkColor($gui_renderbutton, $COLOR_YELLOW)
 
 	GUICtrlSetTip($gui_checkbox_farmmaterialsmidrun, 'Salvage items during runs to save space. Bot will take some salvage kits in inventory for that.')
+	GUICtrlSetTip($gui_checkbox_salvageintocomponents, 'Salvage the components ticked in Keep components (mods, inscriptions, runes, insignias) out of items not worth keeping, using expert salvage kits. Salvaged components are then stored.')
 	GUICtrlSetTip($gui_checkbox_useconsumables, 'If bot uses consumables (cake, pie, speed boosts, etc), it will do it automatically.')
 	GUICtrlSetTip($gui_checkbox_useconsets, 'If bot can use consets, it will do it automatically.')
 	GUICtrlSetTip($gui_button_openstorage, 'Open Xunlai storage window. Works remotely - view only from explorable areas.')
@@ -373,6 +373,7 @@ Func CreateBotsHubGUI()
 	GUICtrlSetOnEvent($gui_checkbox_hardmode, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_sharememory, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_farmmaterialsmidrun, 'GuiOptionsHandler')
+	GUICtrlSetOnEvent($gui_checkbox_salvageintocomponents, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_useconsumables, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_useconsets, 'GuiOptionsHandler')
 	GUICtrlSetOnEvent($gui_checkbox_usescrolls, 'GuiOptionsHandler')
@@ -732,6 +733,8 @@ Func GuiOptionsHandler()
 			$run_options_cache['run.share_memory'] = GUICtrlRead($gui_checkbox_sharememory) == $GUI_CHECKED
 		Case $gui_checkbox_farmmaterialsmidrun
 			$run_options_cache['run.farm_materials_mid_run'] = GUICtrlRead($gui_checkbox_farmmaterialsmidrun) == $GUI_CHECKED
+		Case $gui_checkbox_salvageintocomponents
+			$run_options_cache['run.salvage_into_components'] = GUICtrlRead($gui_checkbox_salvageintocomponents) == $GUI_CHECKED
 		Case $gui_checkbox_useconsumables
 			$run_options_cache['run.consume_consumables'] = GUICtrlRead($gui_checkbox_useconsumables) == $GUI_CHECKED
 		Case $gui_checkbox_useconsets
@@ -1688,6 +1691,7 @@ Func ApplyConfigToGUI()
 	GUICtrlSetState($gui_checkbox_hardmode, $run_options_cache['run.hard_mode'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_sharememory, $run_options_cache['run.share_memory'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_farmmaterialsmidrun, $run_options_cache['run.farm_materials_mid_run'] ? $GUI_CHECKED : $GUI_UNCHECKED)
+	GUICtrlSetState($gui_checkbox_salvageintocomponents, $run_options_cache['run.salvage_into_components'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_useconsumables, $run_options_cache['run.consume_consumables'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_useconsets, $run_options_cache['run.use_consets'] ? $GUI_CHECKED : $GUI_UNCHECKED)
 	GUICtrlSetState($gui_checkbox_usescrolls, $run_options_cache['run.use_scrolls'] ? $GUI_CHECKED : $GUI_UNCHECKED)

--- a/lib/Build_XA_Assassins-Promise.au3
+++ b/lib/Build_XA_Assassins-Promise.au3
@@ -1,0 +1,345 @@
+#CS ===========================================================================
+; Author: caustic-kronos (aka Kronos, Night, Svarog)
+; Copyright 2026 caustic-kronos
+;
+; Licensed under the Apache License, Version 2.0 (the 'License');
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an 'AS IS' BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+#CE ===========================================================================
+
+#include-once
+#include 'GWA2.au3'
+#include 'GWA2_ID.au3'
+#include 'GWA2_ID_Skills.au3'
+#include 'Utils.au3'
+#include 'Utils-Agents.au3'
+
+; ============================================================================
+; Assassin's Promise build support - any primary profession with /A secondary
+;
+; https://gwpvx.fandom.com/wiki/Build:Me/A_Assassin%27s_Promise
+; https://gwpvx.fandom.com/wiki/Build:N/A_Assassin%27s_Promise_Death_Magic
+; https://gwpvx.fandom.com/wiki/Build:E/A_Assassin%27s_Promise
+;
+; Call SetupAPBuild() once during setup - SetupPlayerBuildOverrides does it automatically
+; when Assassin's Promise is found on the skillbar. The combat routine APCombat then
+; replaces the "cast from skill 1 to 8" routine on the move-aggro-kill option maps.
+;
+; Casting rules, one skill per loop iteration, highest priority first:
+;	1. Assassin's Promise once the target is at or below $AP_CAST_HEALTH_THRESHOLD
+;	   Never while Auspicious Incantation or Arcane Echo wait for a spell that Ebon Vanguard Assassin Support can provide
+;	2. "Finish Him!" once the target is below 50% - it has no effect above that
+;	3. "You Move Like a Dwarf!" after "Finish Him!" was used on the target, or when "Finish Him!" cannot be used,
+;	   or when its damage would bring the target below 50% while keeping enough energy for "Finish Him!"
+;	4. Mesmer: Auspicious Incantation, then Arcane Echo, then Ebon Vanguard Assassin Support and its echoed copy
+;	   Auspicious Incantation is only cast when Arcane Echo or Ebon Vanguard Assassin Support will consume it
+;	   Arcane Echo is only cast when Ebon Vanguard Assassin Support can follow immediately
+;	5. Ebon Vanguard Assassin Support
+;	6. Any other skill on the bar, from left to right, keeping an energy reserve for one shout
+;
+; Any non-spell skill ends Arcane Echo, so shouts are never used while Arcane Echo waits for
+; a spell or holds an unused copy of Ebon Vanguard Assassin Support.
+; ============================================================================
+
+; Tunables
+Global Const $AP_CAST_HEALTH_THRESHOLD			= 0.6	; Assassin's Promise is cast at or below this target health fraction
+Global Const $AP_FINISH_HIM_HEALTH_THRESHOLD	= 0.5	; "Finish Him!" has no effect at or above this target health fraction
+Global Const $AP_FILLER_ENERGY_RESERVE			= 10	; energy kept aside when casting non-core skills - enough for one shout
+Global Const $AP_SHOUT_DAMAGE_CONFIDENCE		= 0.9	; safety factor on expected shout damage when predicting a drop below 50%
+Global Const $AP_ENERGY_HEADROOM_FOR_REFUND		= 10	; Auspicious Incantation is not worth casting when this close to max energy
+Global Const $AP_IDLE_SLEEP						= 250	; sleep when no skill can be used
+
+; Damage of "Finish Him!" and "You Move Like a Dwarf!" per Norn rank, and title points needed to reach each rank
+Global Const $AP_NORN_SHOUT_DAMAGE[]			= [44, 51, 58, 66, 73, 80, 80, 80, 80, 80, 80]
+Global Const $AP_NORN_RANK_POINTS[]				= [1000, 2000, 4000, 8000, 16000, 25000, 40000, 65000, 100000, 160000]
+
+; Skill slots detected by SetupAPBuild - -1 when the skill is not on the bar
+Global $BUILD_XA_ASSASSINS_PROMISE				= -1
+Global $BUILD_XA_FINISH_HIM						= -1
+Global $BUILD_XA_YOU_MOVE_LIKE_A_DWARF			= -1
+Global $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT	= -1
+Global $BUILD_XA_ARCANE_ECHO					= -1
+Global $BUILD_XA_AUSPICIOUS_INCANTATION			= -1
+
+
+;~ Set up the Assassin's Promise build: learn the skill slots and set the combat function.
+;~ Overwrites the default combat function on the option maps so all MoveAggro* calls use it.
+;~ Returns True if the build was recognised, False otherwise (default combat function is kept).
+Func SetupAPBuild()
+	$BUILD_XA_ASSASSINS_PROMISE				= -1
+	$BUILD_XA_FINISH_HIM					= -1
+	$BUILD_XA_YOU_MOVE_LIKE_A_DWARF			= -1
+	$BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT	= -1
+	$BUILD_XA_ARCANE_ECHO					= -1
+	$BUILD_XA_AUSPICIOUS_INCANTATION		= -1
+
+	Local $skillbar = GetSkillbar(0)
+	Local $fillerSlots = ''
+	For $i = 1 To 8
+		Local $skillID = DllStructGetData($skillbar, 'SkillID' & $i)
+		Switch $skillID
+			Case $ID_ASSASSINS_PROMISE
+				$BUILD_XA_ASSASSINS_PROMISE = $i
+			Case $ID_FINISH_HIM
+				$BUILD_XA_FINISH_HIM = $i
+			Case $ID_YOU_MOVE_LIKE_A_DWARF
+				$BUILD_XA_YOU_MOVE_LIKE_A_DWARF = $i
+			Case $ID_EBON_VANGUARD_ASSASSIN_SUPPORT
+				$BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT = $i
+			Case $ID_ARCANE_ECHO
+				$BUILD_XA_ARCANE_ECHO = $i
+			Case $ID_AUSPICIOUS_INCANTATION
+				$BUILD_XA_AUSPICIOUS_INCANTATION = $i
+			Case 0
+				; empty slot
+			Case Else
+				$fillerSlots &= ($fillerSlots == '' ? '' : ', ') & $i
+		EndSwitch
+	Next
+
+	If $BUILD_XA_ASSASSINS_PROMISE < 0 Then
+		Warn('Assassin''s Promise is not on the skillbar - keeping the default combat routine')
+		Return False
+	EndIf
+
+	Info('Assassin''s Promise build detected - using the build-aware combat routine')
+	Debug('AP build slots - Promise: ' & $BUILD_XA_ASSASSINS_PROMISE & ', Finish Him: ' & $BUILD_XA_FINISH_HIM _
+		& ', Move Like a Dwarf: ' & $BUILD_XA_YOU_MOVE_LIKE_A_DWARF & ', Assassin Support: ' & $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT _
+		& ', Arcane Echo: ' & $BUILD_XA_ARCANE_ECHO & ', Auspicious Incantation: ' & $BUILD_XA_AUSPICIOUS_INCANTATION _
+		& ', other skills played from left to right: ' & ($fillerSlots == '' ? 'none' : $fillerSlots))
+	If $BUILD_XA_FINISH_HIM < 0 Then Warn('"Finish Him!" is not on the skillbar - Assassin''s Promise build will be weaker')
+	If $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT < 0 Then Warn('Ebon Vanguard Assassin Support is not on the skillbar - Assassin''s Promise build will be weaker')
+	If $BUILD_XA_ARCANE_ECHO > 0 And $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT < 0 Then Warn('Arcane Echo has nothing to copy without Ebon Vanguard Assassin Support - it will not be used')
+
+	$default_move_aggro_kill_options['killMethod']	= APCombat
+	$flag_move_aggro_kill_options['killMethod']		= APCombat
+	$optionsFollower['killMethod']					= APCombat
+	Return True
+EndFunc
+
+
+;~ Combat callback for KillFoesInArea: attacks and uses one skill per iteration according to the Assassin's Promise rules until target is dead.
+Func APCombat($target, $options)
+	Local $abortCondition		= $options['abortCondition'] <> Null ?		$options['abortCondition'] : Null
+
+	; get as close as possible to target foe to have a surprise effect when attacking
+	GetAlmostInRangeOfAgent($target)
+	While $target <> Null And Not GetIsDead($target) And DllStructGetData($target, 'HealthPercent') > 0 And DllStructGetData($target, 'ID') <> 0 And DllStructGetData($target, 'Allegiance') == $ID_ALLEGIANCE_FOE
+		; Always ensure auto-attack is active before using skills - wand and staff hits add up
+		Attack($target)
+		PingSleep(100)
+		If Not CastAssassinsPromiseSkill($target) Then RandomSleep($AP_IDLE_SLEEP)
+		$target = GetCurrentTarget()
+		If IsPlayerDead() Then ExitLoop
+		If $abortCondition <> Null And $abortCondition() Then Return
+	WEnd
+EndFunc
+
+
+;~ Use at most one skill on the target according to the Assassin's Promise rules.
+;~ Returns True if a skill was used, False if nothing could be used this iteration.
+Func CastAssassinsPromiseSkill($target)
+	Local Static $lastTargetID = 0
+	Local Static $finishHimUsed = False
+
+	; Per target state - "Finish Him!" is tracked per target so "You Move Like a Dwarf!" follows it
+	Local $targetID = DllStructGetData($target, 'ID')
+	If $targetID <> $lastTargetID Then
+		$lastTargetID = $targetID
+		$finishHimUsed = False
+	EndIf
+
+	; One snapshot of the skillbar and energy per iteration to limit memory reads
+	Local $skillbar = GetSkillbar()
+	Local $skillTimer = GetSkillTimer()
+	Local $energy = GetEnergy()
+	Local $targetHealth = DllStructGetData($target, 'HealthPercent')
+
+	; Arcane Echo state - its slot shows the copied skill ID while a copy exists
+	Local $echoSlotID = 0, $echoWaitingForSpell = False, $echoCopyReady = False
+	If $BUILD_XA_ARCANE_ECHO > 0 Then
+		$echoSlotID = DllStructGetData($skillbar, 'SkillID' & $BUILD_XA_ARCANE_ECHO)
+		If $echoSlotID == $ID_ARCANE_ECHO Then $echoWaitingForSpell = GetEffect($ID_ARCANE_ECHO) <> Null
+		If $echoSlotID == $ID_EBON_VANGUARD_ASSASSIN_SUPPORT Then $echoCopyReady = IsSkillRecharged($skillbar, $BUILD_XA_ARCANE_ECHO, $skillTimer)
+	EndIf
+	; Any non-spell skill ends Arcane Echo, so shouts wait until the copy has been created and spent
+	Local $shoutsAllowed = Not $echoWaitingForSpell And Not $echoCopyReady
+	Local $auspiciousActive = False
+	If $BUILD_XA_AUSPICIOUS_INCANTATION > 0 Then $auspiciousActive = GetEffect($ID_AUSPICIOUS_INCANTATION) <> Null
+
+	Local $canAssassinSupport = IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $energy)
+	Local $canArcaneEcho = CanCastArcaneEcho($skillbar, $skillTimer, $energy, $echoSlotID, $echoWaitingForSpell, $auspiciousActive)
+
+	; 1. Assassin's Promise once the target is getting close to 50% - the kill then recharges everything and refunds energy
+	If $targetHealth <= $AP_CAST_HEALTH_THRESHOLD And IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_ASSASSINS_PROMISE, $energy) Then
+		; Auspicious Incantation must never be spent on Assassin's Promise, and Arcane Echo should copy Ebon Vanguard Assassin Support
+		; Both are only respected when the spell they wait for can actually be cast - otherwise the kill matters more
+		Local $spellPending = ($auspiciousActive And ($canAssassinSupport Or $canArcaneEcho)) Or ($echoWaitingForSpell And $canAssassinSupport)
+		If Not $spellPending Then Return UseAPSkill($BUILD_XA_ASSASSINS_PROMISE, $target, 'Assassin''s Promise')
+	EndIf
+
+	; 2. "Finish Him!" only below 50% - deep wound, cracked armor and damage
+	If $shoutsAllowed And $targetHealth < $AP_FINISH_HIM_HEALTH_THRESHOLD And IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_FINISH_HIM, $energy) Then
+		If UseAPSkill($BUILD_XA_FINISH_HIM, $target, '"Finish Him!"') Then
+			$finishHimUsed = True
+			Return True
+		EndIf
+	EndIf
+
+	; 3. "You Move Like a Dwarf!" after "Finish Him!", or when it would bring the target below 50% with energy left for "Finish Him!"
+	If $shoutsAllowed And IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_YOU_MOVE_LIKE_A_DWARF, $energy) Then
+		Local $finishHimOnBar = $BUILD_XA_FINISH_HIM > 0
+		Local $finishHimReady = False
+		If $finishHimOnBar Then $finishHimReady = IsSkillRecharged($skillbar, $BUILD_XA_FINISH_HIM, $skillTimer)
+		If $targetHealth < $AP_FINISH_HIM_HEALTH_THRESHOLD Then
+			; "Finish Him!" had priority above - if it was not used here it is either done, recharging or missing
+			If $finishHimUsed Or Not $finishHimReady Then Return UseAPSkill($BUILD_XA_YOU_MOVE_LIKE_A_DWARF, $target, '"You Move Like a Dwarf!"')
+		Else
+			Local $maxHealth = GetAgentMaxHealthEstimate($target)
+			Local $expectedDamage = GetNornShoutDamage() * $AP_SHOUT_DAMAGE_CONFIDENCE
+			Local $wouldDropBelowHalf = ($targetHealth * $maxHealth - $expectedDamage) < ($AP_FINISH_HIM_HEALTH_THRESHOLD * $maxHealth)
+			Local $finishHimCost = $finishHimOnBar ? GetSkillEnergyCost($ID_FINISH_HIM) : 0
+			Local $energyLeftForFinishHim = $energy >= GetSkillEnergyCost($ID_YOU_MOVE_LIKE_A_DWARF) + $finishHimCost
+			If $wouldDropBelowHalf And (Not $finishHimOnBar Or $finishHimReady) And $energyLeftForFinishHim Then Return UseAPSkill($BUILD_XA_YOU_MOVE_LIKE_A_DWARF, $target, '"You Move Like a Dwarf!"')
+		EndIf
+	EndIf
+
+	; 4. Mesmer energy and copy management - only worth starting while the target is still healthy, the spike takes a few seconds
+	If $targetHealth > $AP_CAST_HEALTH_THRESHOLD And Not $echoWaitingForSpell And Not $echoCopyReady Then
+		; Auspicious Incantation refunds more than the cost of the next spell - Arcane Echo is the best candidate, Ebon Vanguard Assassin Support is fine
+		If Not $auspiciousActive And IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_AUSPICIOUS_INCANTATION, $energy) And $energy <= GetMaxEnergy() - $AP_ENERGY_HEADROOM_FOR_REFUND Then
+			Local $energyAfterIncantation = $energy - GetSkillEnergyCost($ID_AUSPICIOUS_INCANTATION)
+			Local $echoAffordable = CanCastArcaneEcho($skillbar, $skillTimer, $energyAfterIncantation, $echoSlotID, $echoWaitingForSpell, True)
+			Local $assassinSupportAffordable = IsAPSlotUsable($skillbar, $skillTimer, $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $energyAfterIncantation)
+			If $echoAffordable Or $assassinSupportAffordable Then Return UseAPSkill($BUILD_XA_AUSPICIOUS_INCANTATION, Null, 'Auspicious Incantation')
+		EndIf
+		; Arcane Echo only right before Ebon Vanguard Assassin Support
+		If $canArcaneEcho Then Return UseAPSkill($BUILD_XA_ARCANE_ECHO, Null, 'Arcane Echo')
+	EndIf
+
+	; 5. Ebon Vanguard Assassin Support - the original first so Arcane Echo gets its copy, then the copy on the same target for a double spike
+	If $echoWaitingForSpell And $canAssassinSupport Then Return UseAPSkill($BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $target, 'Ebon Vanguard Assassin Support (to be echoed)')
+	If $echoCopyReady And $energy >= GetSkillEnergyCost($ID_EBON_VANGUARD_ASSASSIN_SUPPORT) Then Return UseAPSkill($BUILD_XA_ARCANE_ECHO, $target, 'Ebon Vanguard Assassin Support (echoed copy)')
+	If $canAssassinSupport Then Return UseAPSkill($BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $target, 'Ebon Vanguard Assassin Support')
+
+	; 6. Anything else on the bar, from left to right
+	Return UseAPFillerSkill($skillbar, $skillTimer, $energy, $target)
+EndFunc
+
+
+;~ Arcane Echo is only cast when Ebon Vanguard Assassin Support is recharged and there is energy for Arcane Echo,
+;~ Ebon Vanguard Assassin Support and its echoed copy. With Auspicious Incantation active the refund covers Arcane Echo itself.
+Func CanCastArcaneEcho($skillbar, $skillTimer, $energy, $echoSlotID, $echoWaitingForSpell, $auspiciousActive)
+	If $BUILD_XA_ARCANE_ECHO < 0 Or $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT < 0 Then Return False
+	If $echoSlotID <> $ID_ARCANE_ECHO Or $echoWaitingForSpell Then Return False
+	If Not IsSkillRecharged($skillbar, $BUILD_XA_ARCANE_ECHO, $skillTimer) Then Return False
+	If Not IsSkillRecharged($skillbar, $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $skillTimer) Then Return False
+	Local $echoCost = GetSkillEnergyCost($ID_ARCANE_ECHO)
+	Local $assassinSupportCost = GetSkillEnergyCost($ID_EBON_VANGUARD_ASSASSIN_SUPPORT)
+	Local $energyNeeded = $auspiciousActive ? _Max($echoCost, 2 * $assassinSupportCost) : $echoCost + 2 * $assassinSupportCost
+	Return $energy >= $energyNeeded
+EndFunc
+
+
+;~ Use the next non-core skill that is recharged and affordable, rotating from left to right across calls.
+;~ Keeps $AP_FILLER_ENERGY_RESERVE energy aside so a shout stays available for the spike.
+Func UseAPFillerSkill($skillbar, $skillTimer, $energy, $target)
+	Local Static $nextSlot = 1
+	For $offset = 0 To 7
+		Local $slot = Mod($nextSlot - 1 + $offset, 8) + 1
+		If IsAPCoreSlot($slot) Then ContinueLoop
+		Local $skillID = DllStructGetData($skillbar, 'SkillID' & $slot)
+		If $skillID == 0 Then ContinueLoop
+		If Not IsSkillRecharged($skillbar, $slot, $skillTimer) Then ContinueLoop
+		If $energy < GetSkillEnergyCost($skillID) + $AP_FILLER_ENERGY_RESERVE Then ContinueLoop
+		$nextSlot = Mod($slot, 8) + 1
+		Return UseAPSkill($slot, $target)
+	Next
+	Return False
+EndFunc
+
+
+;~ Return True if the slot holds one of the skills handled by the Assassin's Promise rules
+Func IsAPCoreSlot($slot)
+	Switch $slot
+		Case $BUILD_XA_ASSASSINS_PROMISE, $BUILD_XA_FINISH_HIM, $BUILD_XA_YOU_MOVE_LIKE_A_DWARF, $BUILD_XA_EBON_VANGUARD_ASSASSIN_SUPPORT, $BUILD_XA_ARCANE_ECHO, $BUILD_XA_AUSPICIOUS_INCANTATION
+			Return True
+	EndSwitch
+	Return False
+EndFunc
+
+
+;~ Return True if the slot exists, is recharged and its skill is affordable with the given energy
+Func IsAPSlotUsable($skillbar, $skillTimer, $slot, $energy)
+	If $slot < 1 Then Return False
+	If Not IsSkillRecharged($skillbar, $slot, $skillTimer) Then Return False
+	Return $energy >= GetSkillEnergyCost(DllStructGetData($skillbar, 'SkillID' & $slot))
+EndFunc
+
+
+;~ Use a skill and report whether it went off. UseSkillEx can time out on instant skills (shouts) before the
+;~ recharge is visible, so the recharge state is checked again after a short delay.
+Func UseAPSkill($slot, $target = Null, $name = '')
+	If $name <> '' Then Debug('AP build - ' & $name)
+	Local $used = UseSkillEx($slot, $target)
+	If Not $used Then
+		PingSleep(100)
+		$used = Not IsRecharged($slot)
+	EndIf
+	Return $used
+EndFunc
+
+
+;~ Energy cost of a skill - the game stores 15 and 25 energy as special values
+Func GetSkillEnergyCost($skillID)
+	Local Static $costs[]
+	If $skillID == 0 Then Return 0
+	If MapExists($costs, $skillID) Then Return $costs[$skillID]
+	Local $cost = DllStructGetData(GetSkillByID($skillID), 'EnergyCost')
+	Switch $cost
+		Case 11
+			$cost = 15
+		Case 12
+			$cost = 25
+	EndSwitch
+	$costs[$skillID] = $cost
+	Return $cost
+EndFunc
+
+
+;~ Maximum energy of the player
+Func GetMaxEnergy()
+	Return DllStructGetData(GetMyAgent(), 'MaxEnergy')
+EndFunc
+
+
+;~ Maximum health of an agent - foes do not always expose it, so fall back to the usual creature health for their level
+Func GetAgentMaxHealthEstimate($agent)
+	Local $maxHealth = DllStructGetData($agent, 'MaxHealth')
+	If $maxHealth > 0 Then Return $maxHealth
+	Return 100 + 20 * DllStructGetData($agent, 'Level')
+EndFunc
+
+
+;~ Norn title rank, derived from title points
+Func GetNornRank()
+	Local $points = GetNornTitle()
+	Local $rank = 0
+	For $threshold In $AP_NORN_RANK_POINTS
+		If $points >= $threshold Then $rank += 1
+	Next
+	Return $rank
+EndFunc
+
+
+;~ Damage dealt by "Finish Him!" and "You Move Like a Dwarf!" at the current Norn rank
+Func GetNornShoutDamage()
+	Return $AP_NORN_SHOUT_DAMAGE[GetNornRank()]
+EndFunc

--- a/lib/Utils-Items_Modstructs.au3
+++ b/lib/Utils-Items_Modstructs.au3
@@ -21,6 +21,7 @@
 #include 'GWA2_ID_Items.au3'
 #include 'Utils.au3'
 #include 'Utils-Console.au3'
+#include 'Utils-Loot_Configuration.au3'
 #include 'Utils-Storage.au3'
 
 Global Const $STRUCT_WEAPON_UPGRADE		= '30'
@@ -158,7 +159,6 @@ Global Const $STRUCT_INSCRIPTION_PURE_OF_HEART				= '00065828'					;-20 poison d
 Global Const $STRUCT_INSCRIPTION_ONLY_THE_STRONG_SURVIVE	= '00085828'					;-20 weakness duration					; incorrect
 #EndRegion Focus and Shield Inscriptions
 #EndRegion Offhand Inscriptions
-
 
 
 #Region Mods
@@ -1198,9 +1198,11 @@ Global $valuable_prefix_mods_by_weapon_type[]
 Global $valuable_suffix_mods_by_weapon_type[]
 Global $valuable_insignias_structs_array[]
 Global $valuable_runes_structs_array[]
+; Decisions of the Mods section by mod structure, for loose components - see RefreshComponentDecisionsByStruct
+Global $component_decisions_by_struct[]
 
 
-;~ Replace valuable runes/insignias/inscriptions/mods default lists by the lists of elements present in cache
+;~ Replace valuable runes/insignias/inscriptions/mods default lists by the lists of elements salvaged according to the Mods section
 Func RefreshValuableListsFromCache()
 	$valuable_runes_and_insignias_structs_array = CreateValuableRunesAndInsigniasArray()
 	;$valuable_mods_by_os_weapon_type = CreateValuableModsByOSWeaponTypeMap()
@@ -1210,16 +1212,17 @@ Func RefreshValuableListsFromCache()
 	$valuable_suffix_mods_by_weapon_type = CreateValuableModsBySlotByWeaponTypeMap('Suffix')
 	$valuable_insignias_structs_array = CreateValuableArmorUpgradesArray('Insignias')
 	$valuable_runes_structs_array = CreateValuableArmorUpgradesArray('Runes')
+	RefreshComponentDecisionsByStruct()
 EndFunc
 
 
 ;~ Creates an array of all valuable runes and insignias based on selected elements in treeview
 Func CreateValuableRunesAndInsigniasArray()
-	Local $tickedRunesAndInsignias = GetAllChecked($inventory_management_cache, 'Keep components.Armor upgrades', 3, 3)
+	Local $tickedRunesAndInsignias = GetAllChecked($inventory_management_cache, 'Mods.Armor upgrades', 3, 3)
 	Local $valuableRunesAndInsigniasStructsArray[UBound($tickedRunesAndInsignias)]
 	For $i = 0 To UBound($tickedRunesAndInsignias) - 1
-		; removing leftmost string with dot 'Keep components.Armor upgrades.'
-		Local $varName = StringTrimLeft($tickedRunesAndInsignias[$i], 31)
+		; removing leftmost string with dot 'Mods.Armor upgrades.'
+		Local $varName = StringTrimLeft($tickedRunesAndInsignias[$i], StringLen($LOOT_ROOT_MODS & '.' & $LOOT_ARMOR_UPGRADES_GROUP & '.'))
 		$varName = 'Struct_' & StringReplace(StringReplace($varName, '.', '_'), ' ', '_')
 		$valuableRunesAndInsigniasStructsArray[$i] = SafeEval($varName)
 	Next
@@ -1230,12 +1233,12 @@ EndFunc
 ;~ Creates an array of the valuable armor upgrades of one category ('Insignias' or 'Runes') based on selected elements in treeview
 ;~ Insignias sit at salvage index 0 and runes at index 1 of their armor salvageable item, hence the split
 Func CreateValuableArmorUpgradesArray($category)
-	Local $tickedRunesAndInsignias = GetAllChecked($inventory_management_cache, 'Keep components.Armor upgrades', 3, 3)
+	Local $tickedRunesAndInsignias = GetAllChecked($inventory_management_cache, 'Mods.Armor upgrades', 3, 3)
 	Local $valuableStructsArray[0]
 	For $tickedElement In $tickedRunesAndInsignias
 		If Not StringInStr($tickedElement, '.' & $category & '.') Then ContinueLoop
-		; removing leftmost string with dot 'Keep components.Armor upgrades.'
-		Local $varName = StringTrimLeft($tickedElement, 31)
+		; removing leftmost string with dot 'Mods.Armor upgrades.'
+		Local $varName = StringTrimLeft($tickedElement, StringLen($LOOT_ROOT_MODS & '.' & $LOOT_ARMOR_UPGRADES_GROUP & '.'))
 		$varName = 'Struct_' & StringReplace(StringReplace($varName, '.', '_'), ' ', '_')
 		_ArrayAdd($valuableStructsArray, SafeEval($varName))
 	Next
@@ -1246,7 +1249,7 @@ EndFunc
 ;~ TODO: finish this function
 ;~ Creates an array of all valuable OS (Old School without inscription) weapon mods based on selected elements in treeview
 Func CreateValuableModsByOSWeaponTypeMap()
-	Local $tickedMods = GetAllChecked($inventory_management_cache, 'Keep components.Mods')
+	Local $tickedMods = GetAllChecked($inventory_management_cache, 'Mods.Weapon mods')
 	Local $valuableModsByOSWeaponTypeMap[UBound($tickedMods)]
 	For $tickedMod In $tickedMods
 		Info($tickedMods)
@@ -1295,7 +1298,7 @@ Func CreateValuableModsByWeaponTypeMap()
 	Local $weaponModsByType[]
 	For $weaponType In $allWeaponsArray
 		Local $weaponName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
-		Local $tickedMods = GetAllChecked($inventory_management_cache, 'Keep components.Mods.' & $weaponName, 2, 2)
+		Local $tickedMods = GetAllChecked($inventory_management_cache, 'Mods.Weapon mods.' & $weaponName, 2, 2)
 		Local $count = UBound($tickedMods)
 		Local $mods[$count]
 
@@ -1308,8 +1311,8 @@ Func CreateValuableModsByWeaponTypeMap()
 		Local $suffixRule = $suffixWeaponModRules[$weaponName]
 		For $j = 0 To $count - 1
 			Local $varName = $tickedMods[$j]
-			; Removing Keep components.Mods.
-			$varName = StringTrimLeft($varName, 21)
+			; Removing Mods.Weapon mods.
+			$varName = StringTrimLeft($varName, StringLen($LOOT_ROOT_MODS & '.' & $LOOT_WEAPON_MODS_GROUP & '.'))
 			If $prefixRule <> Null Then $varName = StringReplace($varName, $prefixRule, 'STRUCT_MOD_')
 			If $suffixRule <> Null Then $varName = StringReplace($varName, $suffixRule, 'STRUCT_MOD_')
 			$varName = ModNameCleanupHelper($varName)
@@ -1324,19 +1327,19 @@ EndFunc
 
 ;~ Creates a map of all valuable inscriptions based on selected elements in cache
 Func CreateValuableInscriptionsByWeaponTypeMap()
-	Local $tickedInscriptionAll = GetAllChecked($inventory_management_cache, 'Keep components.Inscriptions', 1, 1)
-	Local $tickedInscriptionWeapons = GetAllChecked($inventory_management_cache, 'Keep components.Inscriptions.Weapon', 1, 1)
-	Local $tickedInscriptionWeaponsMartial = GetAllChecked($inventory_management_cache, 'Keep components.Inscriptions.Weapon.Martial', 1, 1)
-	Local $tickedInscriptionWeaponsSpellcasting = GetAllChecked($inventory_management_cache, 'Keep components.Inscriptions.Weapon.Spellcasting', 1, 1)
-	Local $tickedInscriptionOffhand = GetAllChecked($inventory_management_cache, 'Keep components.Inscriptions.Offhand', 1, 1)
-	Local $tickedInscriptionOffhandFocus = GetAllChecked($inventory_management_cache, 'Keep components.Inscriptions.Offhand.Focus', 1, 1)
+	Local $tickedInscriptionAll = GetAllChecked($inventory_management_cache, 'Mods.Inscriptions', 1, 1)
+	Local $tickedInscriptionWeapons = GetAllChecked($inventory_management_cache, 'Mods.Inscriptions.Weapon', 1, 1)
+	Local $tickedInscriptionWeaponsMartial = GetAllChecked($inventory_management_cache, 'Mods.Inscriptions.Weapon.Martial', 1, 1)
+	Local $tickedInscriptionWeaponsSpellcasting = GetAllChecked($inventory_management_cache, 'Mods.Inscriptions.Weapon.Spellcasting', 1, 1)
+	Local $tickedInscriptionOffhand = GetAllChecked($inventory_management_cache, 'Mods.Inscriptions.Offhand', 1, 1)
+	Local $tickedInscriptionOffhandFocus = GetAllChecked($inventory_management_cache, 'Mods.Inscriptions.Offhand.Focus', 1, 1)
 
 	Local $inscriptionsWeaponsMartial[UBound($tickedInscriptionAll) + UBound($tickedInscriptionWeapons) + UBound($tickedInscriptionWeaponsMartial)]
 	Local $inscriptionsWeaponsSpellcasting[UBound($tickedInscriptionAll) + UBound($tickedInscriptionWeapons) + UBound($tickedInscriptionWeaponsSpellcasting)]
 	Local $inscriptionsFocus[UBound($tickedInscriptionAll) + UBound($tickedInscriptionOffhand) + UBound($tickedInscriptionOffhandFocus)]
 	Local $inscriptionsShield[UBound($tickedInscriptionAll) + UBound($tickedInscriptionOffhand)]
 
-	Local $prefixLength = StringLen('Keep components.Inscriptions.')
+	Local $prefixLength = StringLen('Mods.Inscriptions.')
 	For $i = 0 To UBound($tickedInscriptionAll) - 1
 		Local $inscription = TrimCleanupAndEval($tickedInscriptionAll[$i], $prefixLength)
 		$inscriptionsWeaponsMartial[$i] = $inscription
@@ -1345,29 +1348,29 @@ Func CreateValuableInscriptionsByWeaponTypeMap()
 		$inscriptionsShield[$i] = $inscription
 	Next
 	Local $generalIndex = UBound($tickedInscriptionAll)
-	$prefixLength = StringLen('Keep components.Inscriptions.Weapon.')
+	$prefixLength = StringLen('Mods.Inscriptions.Weapon.')
 	For $i = 0 To UBound($tickedInscriptionWeapons) - 1
 		Local $inscription = TrimCleanupAndEval($tickedInscriptionWeapons[$i], $prefixLength)
 		$inscriptionsWeaponsMartial[$generalIndex + $i] = $inscription
 		$inscriptionsWeaponsSpellcasting[$generalIndex + $i] = $inscription
 	Next
 	Local $weaponIndex = $generalIndex + UBound($tickedInscriptionWeapons)
-	$prefixLength = StringLen('Keep components.Inscriptions.Weapon.Martial.')
+	$prefixLength = StringLen('Mods.Inscriptions.Weapon.Martial.')
 	For $i = 0 To UBound($tickedInscriptionWeaponsMartial) - 1
 		$inscriptionsWeaponsMartial[$weaponIndex + $i] = TrimCleanupAndEval($tickedInscriptionWeaponsMartial[$i], $prefixLength)
 	Next
-	$prefixLength = StringLen('Keep components.Inscriptions.Weapon.Spellcasting.')
+	$prefixLength = StringLen('Mods.Inscriptions.Weapon.Spellcasting.')
 	For $i = 0 To UBound($tickedInscriptionWeaponsSpellcasting) - 1
 		$inscriptionsWeaponsSpellcasting[$weaponIndex + $i] = TrimCleanupAndEval($tickedInscriptionWeaponsSpellcasting[$i], $prefixLength)
 	Next
-	$prefixLength = StringLen('Keep components.Inscriptions.Offhand.')
+	$prefixLength = StringLen('Mods.Inscriptions.Offhand.')
 	For $i = 0 To UBound($tickedInscriptionOffhand) - 1
 		Local $inscription = TrimCleanupAndEval($tickedInscriptionOffhand[$i], $prefixLength)
 		$inscriptionsFocus[$generalIndex + $i] = $inscription
 		$inscriptionsShield[$generalIndex + $i] = $inscription
 	Next
 	Local $offhandIndex = $generalIndex + UBound($tickedInscriptionOffhand)
-	$prefixLength = StringLen('Keep components.Inscriptions.Offhand.Focus.')
+	$prefixLength = StringLen('Mods.Inscriptions.Offhand.Focus.')
 	For $i = 0 To $i + UBound($tickedInscriptionOffhandFocus) - 1
 		$inscriptionsFocus[$offhandIndex + $i] = TrimCleanupAndEval($tickedInscriptionOffhandFocus[$i], $prefixLength)
 	Next
@@ -1408,8 +1411,8 @@ Func CreateValuableModsBySlotByWeaponTypeMap($slotName)
 	Local $weaponModsByType[]
 	For $weaponType In $WEAPON_TYPES_ARRAY
 		Local $weaponName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
-		Local $modsPath = 'Keep components.Mods.' & $weaponName & '.'
-		Local $tickedMods = GetAllChecked($inventory_management_cache, 'Keep components.Mods.' & $weaponName, 2, 2)
+		Local $modsPath = 'Mods.Weapon mods.' & $weaponName & '.'
+		Local $tickedMods = GetAllChecked($inventory_management_cache, 'Mods.Weapon mods.' & $weaponName, 2, 2)
 		Local $mods[0]
 		For $tickedMod In $tickedMods
 			; Relative path looks like 'Prefix - Haft.Sundering (Armor penetration +20% - Chance 20%)'
@@ -1468,3 +1471,47 @@ Func ModNameCleanupHelper($modName)
 	Return $modName
 EndFunc
 #EndRegion Utils
+
+;~ Structure constant of a Mods leaf, following the naming of the mod structure constants - Null when there is none
+;~ Weapon mods: STRUCT_MOD_<NAME>, inscriptions: STRUCT_INSCRIPTION_<NAME>, armor upgrades: Struct_<Profession>_<Insignias|Runes>_<Name>
+Func GetComponentStructForPath($path)
+	Local $modsPrefix = $LOOT_ROOT_MODS & '.'
+	If StringLeft($path, StringLen($modsPrefix)) <> $modsPrefix Then Return Null
+	Local $relative = StringTrimLeft($path, StringLen($modsPrefix))
+	Local $firstDot = StringInStr($relative, '.')
+	Local $lastDot = StringInStr($relative, '.', 0, -1)
+	If $firstDot == 0 Then Return Null
+	Local $group = StringLeft($relative, $firstDot - 1)
+	Local $leafName = StringTrimLeft($relative, $lastDot)
+	Switch $group
+		Case $LOOT_WEAPON_MODS_GROUP
+			Return SafeEval('STRUCT_MOD_' & ModNameCleanupHelper($leafName), False)
+		Case $LOOT_INSCRIPTIONS_GROUP
+			Return SafeEval('STRUCT_INSCRIPTION_' & ModNameCleanupHelper($leafName), False)
+		Case $LOOT_ARMOR_UPGRADES_GROUP
+			Local $afterGroup = StringTrimLeft($relative, $firstDot)
+			Return SafeEval('Struct_' & StringReplace(StringReplace($afterGroup, '.', '_'), ' ', '_'), False)
+	EndSwitch
+	Return Null
+EndFunc
+
+
+;~ Rebuild the decisions of the Mods section by mod structure, for loose components found in the bags
+;~ A structure listed under several weapon types gets the union of their decisions
+Func RefreshComponentDecisionsByStruct()
+	Local $result[]
+	For $path In MapKeys($loot_decisions)
+		If GetLootNodeKind($path) <> $LOOT_KIND_MOD Then ContinueLoop
+		Local $struct = GetComponentStructForPath($path)
+		If $struct == Null Then ContinueLoop
+		If Not IsString($struct) Or $struct == '' Then ContinueLoop
+		Local $decision = ParseModDecision($loot_decisions[$path])
+		If MapExists($result, $struct) Then
+			Local $existing = $result[$struct]
+			If $existing['salvage'] Then $decision['salvage'] = True
+			If $existing['store'] Then $decision['store'] = True
+		EndIf
+		$result[$struct] = $decision
+	Next
+	$component_decisions_by_struct = $result
+EndFunc

--- a/lib/Utils-Items_Modstructs.au3
+++ b/lib/Utils-Items_Modstructs.au3
@@ -1099,6 +1099,42 @@ Func ContainsValuableUpgrades($item)
 EndFunc
 
 
+;~ Returns the salvage slot indices (prefix/insignia 0, suffix/rune 1, inscription 2) of the components worth keeping in the item
+;~ Same detection as ContainsValuableUpgrades, split by slot so the right component can be salvaged out of the item
+Func GetValuableComponentIndices($item)
+	Local $indices[0]
+	Local $modStruct = GetModStruct($item)
+	If Not $modStruct Then Return $indices
+	If IsWeapon($item) Then
+		Local $itemType = DllStructGetData($item, 'type')
+		If ContainsAnyStruct($modStruct, $valuable_prefix_mods_by_weapon_type[$itemType], $STRUCT_WEAPON_UPGRADE) Then _ArrayAdd($indices, $COMPONENT_INDEX_PREFIX)
+		If ContainsAnyStruct($modStruct, $valuable_suffix_mods_by_weapon_type[$itemType], $STRUCT_WEAPON_UPGRADE) Then _ArrayAdd($indices, $COMPONENT_INDEX_SUFFIX)
+		If IsInscribable($item) And ContainsAnyStruct($modStruct, $valuable_inscriptions_by_weapon_type[$itemType], $STRUCT_INSCRIPTION) Then _ArrayAdd($indices, $COMPONENT_INDEX_INSCRIPTION)
+	ElseIf IsArmorSalvageItem($item) Then
+		If ContainsAnyStruct($modStruct, $valuable_insignias_structs_array) Then _ArrayAdd($indices, $COMPONENT_INDEX_PREFIX)
+		If ContainsAnyStruct($modStruct, $valuable_runes_structs_array) Then _ArrayAdd($indices, $COMPONENT_INDEX_SUFFIX)
+	EndIf
+	Return $indices
+EndFunc
+
+
+;~ Returns true if the modstruct contains one of the given structs - when a header is given, only structs preceded by it count
+;~ Header is the byte in front of the struct: $STRUCT_WEAPON_UPGRADE for weapon mods, $STRUCT_INSCRIPTION for inscriptions
+Func ContainsAnyStruct($modStruct, $structs, $header = Null)
+	If Not IsArray($structs) Then Return False
+	For $struct In $structs
+		If Not IsString($struct) Or $struct == '' Then ContinueLoop
+		Local $upgradePosition = StringInStr($modStruct, $struct)
+		While $upgradePosition > 0
+			If $header == Null Then Return True
+			If $upgradePosition >= 5 And StringMid($modStruct, $upgradePosition - 4, 2) == $header Then Return True
+			$upgradePosition = StringInStr($modStruct, $struct, 0, 1, $upgradePosition + 1)
+		WEnd
+	Next
+	Return False
+EndFunc
+
+
 ;~ Determines whether the provided OS (Old School) item has perfect mods
 Func HasPerfectMods($item)
 	Local $itemType	= DllStructGetData($item, 'type')
@@ -1153,12 +1189,27 @@ Global $valuable_inscriptions_array[]
 Global $valuable_inscriptions_by_weapon_type			= DefaultCreateValuableInscriptionsByWeaponTypeMap()
 
 
+; Salvage slot indices used to salvage a component out of an item: prefix/insignia 0, suffix/rune 1, inscription 2
+Global Const $COMPONENT_INDEX_PREFIX = 0
+Global Const $COMPONENT_INDEX_SUFFIX = 1
+Global Const $COMPONENT_INDEX_INSCRIPTION = 2
+; Valuable components split by salvage slot - filled from the loot configuration, used to salvage components out of items
+Global $valuable_prefix_mods_by_weapon_type[]
+Global $valuable_suffix_mods_by_weapon_type[]
+Global $valuable_insignias_structs_array[]
+Global $valuable_runes_structs_array[]
+
+
 ;~ Replace valuable runes/insignias/inscriptions/mods default lists by the lists of elements present in cache
 Func RefreshValuableListsFromCache()
 	$valuable_runes_and_insignias_structs_array = CreateValuableRunesAndInsigniasArray()
 	;$valuable_mods_by_os_weapon_type = CreateValuableModsByOSWeaponTypeMap()
 	$valuable_mods_by_weapon_type = CreateValuableModsByWeaponTypeMap()
 	$valuable_inscriptions_by_weapon_type = CreateValuableInscriptionsByWeaponTypeMap()
+	$valuable_prefix_mods_by_weapon_type = CreateValuableModsBySlotByWeaponTypeMap('Prefix')
+	$valuable_suffix_mods_by_weapon_type = CreateValuableModsBySlotByWeaponTypeMap('Suffix')
+	$valuable_insignias_structs_array = CreateValuableArmorUpgradesArray('Insignias')
+	$valuable_runes_structs_array = CreateValuableArmorUpgradesArray('Runes')
 EndFunc
 
 
@@ -1173,6 +1224,22 @@ Func CreateValuableRunesAndInsigniasArray()
 		$valuableRunesAndInsigniasStructsArray[$i] = SafeEval($varName)
 	Next
 	Return $valuableRunesAndInsigniasStructsArray
+EndFunc
+
+
+;~ Creates an array of the valuable armor upgrades of one category ('Insignias' or 'Runes') based on selected elements in treeview
+;~ Insignias sit at salvage index 0 and runes at index 1 of their armor salvageable item, hence the split
+Func CreateValuableArmorUpgradesArray($category)
+	Local $tickedRunesAndInsignias = GetAllChecked($inventory_management_cache, 'Keep components.Armor upgrades', 3, 3)
+	Local $valuableStructsArray[0]
+	For $tickedElement In $tickedRunesAndInsignias
+		If Not StringInStr($tickedElement, '.' & $category & '.') Then ContinueLoop
+		; removing leftmost string with dot 'Keep components.Armor upgrades.'
+		Local $varName = StringTrimLeft($tickedElement, 31)
+		$varName = 'Struct_' & StringReplace(StringReplace($varName, '.', '_'), ' ', '_')
+		_ArrayAdd($valuableStructsArray, SafeEval($varName))
+	Next
+	Return $valuableStructsArray
 EndFunc
 
 
@@ -1332,6 +1399,28 @@ Func CreateValuableInscriptionsByWeaponTypeMap()
 		EndSwitch
 	Next
 	Return $inscriptionsByWeaponType
+EndFunc
+
+
+;~ Creates a map of the valuable weapon mods of one salvage slot ('Prefix' or 'Suffix') by weapon type based on selected elements in treeview
+;~ Same elements as CreateValuableModsByWeaponTypeMap, split by slot so the right component can be salvaged out of an item
+Func CreateValuableModsBySlotByWeaponTypeMap($slotName)
+	Local $weaponModsByType[]
+	For $weaponType In $WEAPON_TYPES_ARRAY
+		Local $weaponName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
+		Local $modsPath = 'Keep components.Mods.' & $weaponName & '.'
+		Local $tickedMods = GetAllChecked($inventory_management_cache, 'Keep components.Mods.' & $weaponName, 2, 2)
+		Local $mods[0]
+		For $tickedMod In $tickedMods
+			; Relative path looks like 'Prefix - Haft.Sundering (Armor penetration +20% - Chance 20%)'
+			Local $relativePath = StringTrimLeft($tickedMod, StringLen($modsPath))
+			If StringLeft($relativePath, StringLen($slotName)) <> $slotName Then ContinueLoop
+			Local $modName = StringTrimLeft($relativePath, StringInStr($relativePath, '.'))
+			_ArrayAdd($mods, SafeEval('STRUCT_MOD_' & ModNameCleanupHelper($modName)))
+		Next
+		$weaponModsByType[$weaponType] = $mods
+	Next
+	Return $weaponModsByType
 EndFunc
 #EndRegion Structure creation from UI
 

--- a/lib/Utils-Loot_Configuration.au3
+++ b/lib/Utils-Loot_Configuration.au3
@@ -1,0 +1,596 @@
+#CS ===========================================================================
+; Author: caustic-kronos (aka Kronos, Night, Svarog)
+; Copyright 2026 caustic-kronos
+;
+; Licensed under the Apache License, Version 2.0 (the 'License');
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an 'AS IS' BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+#CE ===========================================================================
+
+#include-once
+#include <Array.au3>
+#include 'JSON.au3'
+#include 'Utils-Console.au3'
+
+; ============================================================================
+; Loot configuration - one decision per item
+;
+; The loot configuration JSON has three roots:
+;	Items		item families > items > sub categories > leaf, each leaf holding one decision string:
+;				'ignore'								the item is neither picked up nor touched in the bags
+;				'[identify+]keep|salvage|sell|store'	the item is picked up, identified first when asked, then kept in the bags,
+;														salvaged, sold or stored
+;	Mods		weapon mods, inscriptions, runes and insignias, each leaf holding:
+;				'ignore'				the mod is left on the item
+;				'salvage+store'			the mod is salvaged out of items that are salvaged or sold, and stored
+;				'salvage+sell'			same, but the salvaged mod is sold
+;	Buy items	booleans, unchanged from the previous format
+;
+; Loaded configurations are kept in two maps:
+;	$loot_decisions				leaf path -> decision, in display order
+;	$inventory_management_cache	every path (leaves and groups) -> True when active, plus the derived '@' flags
+;								a leaf is active when not ignored (items), salvaged (mods) or bought (buy items)
+;								a group is active when all leaves below it are active
+;
+; Configurations saved in the previous format (one tree per action) are migrated on load.
+; This file does not depend on the game and can be tested headless.
+; ============================================================================
+
+Global Const $LOOT_ROOT_ITEMS				= 'Items'
+Global Const $LOOT_ROOT_MODS				= 'Mods'
+Global Const $LOOT_ROOT_BUY					= 'Buy items'
+Global Const $LOOT_ROOTS[]					= [$LOOT_ROOT_ITEMS, $LOOT_ROOT_MODS, $LOOT_ROOT_BUY]
+
+Global Const $LOOT_KIND_ITEM				= 'item'
+Global Const $LOOT_KIND_MOD					= 'mod'
+Global Const $LOOT_KIND_BUY					= 'buy'
+
+Global Const $LOOT_DECISION_IGNORE			= 'ignore'
+Global Const $LOOT_FLAG_IDENTIFY			= 'identify'
+Global Const $LOOT_ACTION_KEEP				= 'keep'
+Global Const $LOOT_ACTION_SALVAGE			= 'salvage'
+Global Const $LOOT_ACTION_SELL				= 'sell'
+Global Const $LOOT_ACTION_STORE				= 'store'
+Global Const $LOOT_ACTIONS[]				= [$LOOT_ACTION_KEEP, $LOOT_ACTION_SALVAGE, $LOOT_ACTION_SELL, $LOOT_ACTION_STORE]
+
+; Families and leaves shared by the configuration and the item classifier
+Global Const $LOOT_MONEY					= 'Gold'
+Global Const $LOOT_WEAPONS_FAMILY			= 'Weapons and offhands'
+Global Const $LOOT_LOW_REQ_RULE				= 'Low req max stats'
+Global Const $LOOT_RARE_SKINS				= 'Rare skins'
+Global Const $LOOT_OTHER_SKINS				= 'Other skins'
+Global Const $LOOT_GREEN_RARITY				= 'Green'
+Global Const $LOOT_WEAPON_MAX_REQ			= 13
+Global Const $LOOT_WEAPON_TYPE_NAMES[]		= ['Axe', 'Sword', 'Dagger', 'Hammer', 'Scythe', 'Spear', 'Bow', 'Wand', 'Staff', 'Focus', 'Shield']
+Global Const $LOOT_WEAPON_RARITY_NAMES[]	= ['White', 'Blue', 'Purple', 'Gold']
+Global Const $LOOT_ARMOR_FAMILY				= 'Armor salvageables'
+Global Const $LOOT_TROPHIES_FAMILY			= 'Trophies'
+Global Const $LOOT_TROPHIES_NICHOLAS		= 'Nicholas trophies'
+Global Const $LOOT_TROPHIES_RARE_MATERIALS	= 'Rare material trophies'
+Global Const $LOOT_TROPHIES_COMMON_MATERIALS = 'Common material trophies'
+Global Const $LOOT_TROPHIES_OTHER			= 'Other trophies'
+Global Const $LOOT_BASIC_MATERIALS_FAMILY	= 'Basic Materials'
+Global Const $LOOT_RARE_MATERIALS_FAMILY	= 'Rare Materials'
+Global Const $LOOT_CONSUMABLES				= 'Consumables'
+Global Const $LOOT_SCROLLS_FAMILY			= 'Scrolls'
+Global Const $LOOT_OTHER_GOLD_SCROLLS		= 'Other gold scrolls'
+Global Const $LOOT_OTHER_FAMILY				= 'Other items'
+Global Const $LOOT_OTHER_STACKABLES			= 'Stackables'
+Global Const $LOOT_OTHER_UNKNOWN			= 'Unknown items'
+; Groups of the Mods root
+Global Const $LOOT_WEAPON_MODS_GROUP		= 'Weapon mods'
+Global Const $LOOT_INSCRIPTIONS_GROUP		= 'Inscriptions'
+Global Const $LOOT_ARMOR_UPGRADES_GROUP		= 'Armor upgrades'
+
+; Leaf path -> decision (string for items and mods, boolean for buy items), in display order
+Global $loot_decisions[]
+; Every path -> active flag, plus derived '@' flags - shared with the whole bot
+Global $inventory_management_cache[]
+
+
+#Region Decisions
+;~ Kind of a configuration node from its path: item, mod, buy or empty when unknown
+Func GetLootNodeKind($path)
+	Local $first = StringInStr($path, '.') > 0 ? StringLeft($path, StringInStr($path, '.') - 1) : $path
+	Switch $first
+		Case $LOOT_ROOT_ITEMS
+			Return $LOOT_KIND_ITEM
+		Case $LOOT_ROOT_MODS
+			Return $LOOT_KIND_MOD
+		Case $LOOT_ROOT_BUY
+			Return $LOOT_KIND_BUY
+	EndSwitch
+	Return ''
+EndFunc
+
+
+;~ Parse an item decision string into a map with keys ignore, identify and action
+Func ParseItemDecision($decision)
+	Local $result[]
+	$decision = StringLower(StringStripWS($decision, 8))
+	$result['ignore'] = ($decision == $LOOT_DECISION_IGNORE)
+	$result['identify'] = False
+	$result['action'] = $LOOT_ACTION_KEEP
+	If $result['ignore'] Then Return $result
+	Local $parts = StringSplit($decision, '+')
+	For $i = 1 To $parts[0]
+		Switch $parts[$i]
+			Case $LOOT_FLAG_IDENTIFY
+				$result['identify'] = True
+			Case $LOOT_ACTION_KEEP, $LOOT_ACTION_SALVAGE, $LOOT_ACTION_SELL, $LOOT_ACTION_STORE
+				$result['action'] = $parts[$i]
+		EndSwitch
+	Next
+	Return $result
+EndFunc
+
+
+;~ Build an item decision string
+Func FormatItemDecision($ignore, $identify, $action)
+	If $ignore Then Return $LOOT_DECISION_IGNORE
+	Return ($identify ? $LOOT_FLAG_IDENTIFY & '+' : '') & $action
+EndFunc
+
+
+;~ Parse a mod decision string into a map with keys salvage and store
+Func ParseModDecision($decision)
+	Local $result[]
+	$decision = StringLower(StringStripWS($decision, 8))
+	$result['salvage'] = StringLeft($decision, StringLen($LOOT_ACTION_SALVAGE)) == $LOOT_ACTION_SALVAGE
+	$result['store'] = $result['salvage'] And StringInStr($decision, '+' & $LOOT_ACTION_STORE) > 0
+	Return $result
+EndFunc
+
+
+;~ Build a mod decision string
+Func FormatModDecision($salvage, $store)
+	If Not $salvage Then Return $LOOT_DECISION_IGNORE
+	Return $LOOT_ACTION_SALVAGE & '+' & ($store ? $LOOT_ACTION_STORE : $LOOT_ACTION_SELL)
+EndFunc
+
+
+;~ Return a valid decision for the node, whatever was found in the file
+Func NormalizeLootDecision($path, $value)
+	Switch GetLootNodeKind($path)
+		Case $LOOT_KIND_BUY
+			Return $value == True
+		Case $LOOT_KIND_ITEM
+			If Not IsString($value) Then Return $LOOT_DECISION_IGNORE
+			Local $parsed = ParseItemDecision($value)
+			Return FormatItemDecision($parsed['ignore'], $parsed['identify'], $parsed['action'])
+		Case $LOOT_KIND_MOD
+			If Not IsString($value) Then Return $LOOT_DECISION_IGNORE
+			Local $parsed = ParseModDecision($value)
+			Return FormatModDecision($parsed['salvage'], $parsed['store'])
+	EndSwitch
+	Return $LOOT_DECISION_IGNORE
+EndFunc
+
+
+;~ True when the decision makes the bot act on the node: item not ignored, mod salvaged, buy item bought
+Func IsLootDecisionActive($path, $decision)
+	Switch GetLootNodeKind($path)
+		Case $LOOT_KIND_ITEM
+			Return $decision <> $LOOT_DECISION_IGNORE
+		Case $LOOT_KIND_MOD
+			Return StringLeft($decision, StringLen($LOOT_ACTION_SALVAGE)) == $LOOT_ACTION_SALVAGE
+		Case $LOOT_KIND_BUY
+			Return $decision == True
+	EndSwitch
+	Return False
+EndFunc
+
+
+;~ True when the leaf exists in the loaded configuration
+Func LootLeafExists($path)
+	Return MapExists($loot_decisions, $path)
+EndFunc
+
+
+;~ Decision of an item leaf as a map with keys ignore, identify and action - Null when the leaf does not exist
+Func GetLootItemDecision($path)
+	If Not MapExists($loot_decisions, $path) Then Return Null
+	Return ParseItemDecision($loot_decisions[$path])
+EndFunc
+
+
+;~ Decision of a mod leaf as a map with keys salvage and store - Null when the leaf does not exist
+Func GetLootModDecision($path)
+	If Not MapExists($loot_decisions, $path) Then Return Null
+	Return ParseModDecision($loot_decisions[$path])
+EndFunc
+
+
+;~ Set one decision and its active flag - group flags are refreshed separately
+Func SetLootDecision($path, $decision)
+	$loot_decisions[$path] = $decision
+	$inventory_management_cache[$path] = IsLootDecisionActive($path, $decision)
+EndFunc
+
+
+;~ Replace every decision by those of the given map and rebuild the cache - used by the GUI when changes are applied
+Func ApplyLootDecisions($decisions)
+	Local $emptyDecisions[]
+	Local $emptyCache[]
+	$loot_decisions = $emptyDecisions
+	$inventory_management_cache = $emptyCache
+	For $path In MapKeys($decisions)
+		SetLootDecision($path, $decisions[$path])
+	Next
+	RefreshLootGroupFlags()
+	BuildInventoryDerivedFlags()
+EndFunc
+
+
+;~ Recompute the active flag of every group: a group is active when all leaves below it are active
+Func RefreshLootGroupFlags()
+	Local $groups[]
+	For $path In MapKeys($loot_decisions)
+		Local $active = $inventory_management_cache[$path]
+		Local $parts = StringSplit($path, '.')
+		Local $current = ''
+		For $i = 1 To $parts[0] - 1
+			$current &= ($i == 1 ? '' : '.') & $parts[$i]
+			If Not MapExists($groups, $current) Then $groups[$current] = True
+			If Not $active Then $groups[$current] = False
+		Next
+	Next
+	For $group In MapKeys($groups)
+		$inventory_management_cache[$group] = $groups[$group]
+	Next
+EndFunc
+#EndRegion Decisions
+
+
+#Region Loading and saving
+;~ Load a parsed loot configuration into $loot_decisions and $inventory_management_cache
+;~ Configurations in the previous format (one tree per action) are migrated first
+;~ Returns True when a configuration was loaded
+Func LoadLootDecisionsFromJson($json)
+	If Not IsMap($json) Then Return False
+	If Not MapExists($json, $LOOT_ROOT_ITEMS) And MapExists($json, 'Pick up items') Then
+		Info('Loot configuration uses the previous format (one tree per action) - migrating it to one decision per item')
+		$json = MigrateLootConfigurationV1($json)
+	EndIf
+	Local $emptyDecisions[]
+	Local $emptyCache[]
+	$loot_decisions = $emptyDecisions
+	$inventory_management_cache = $emptyCache
+	For $root In $LOOT_ROOTS
+		If MapExists($json, $root) Then LoadLootDecisionsNode($json[$root], $root)
+	Next
+	BuildInventoryDerivedFlags()
+	Return True
+EndFunc
+
+
+;~ Recursive part of the loading - returns True when every leaf below the node is active
+Func LoadLootDecisionsNode($node, $path)
+	If IsMap($node) Then
+		Local $allActive = True
+		For $key In MapKeys($node)
+			If Not LoadLootDecisionsNode($node[$key], $path & '.' & $key) Then $allActive = False
+		Next
+		$inventory_management_cache[$path] = $allActive
+		Return $allActive
+	EndIf
+	Local $decision = NormalizeLootDecision($path, $node)
+	$loot_decisions[$path] = $decision
+	Local $active = IsLootDecisionActive($path, $decision)
+	$inventory_management_cache[$path] = $active
+	Return $active
+EndFunc
+
+
+;~ Build the JSON object of a loot configuration from decisions, in their display order
+Func BuildLootJson($decisions = Null)
+	If $decisions == Null Then $decisions = $loot_decisions
+	Local $json[]
+	For $path In MapKeys($decisions)
+		_JSON_addChangeDelete($json, $path, $decisions[$path])
+	Next
+	Return $json
+EndFunc
+#EndRegion Loading and saving
+
+
+#Region Derived flags
+;~ Flags summarising the configuration, used by the bot to skip useless trips to town
+;~ '@<action>.something' and '@<action>.nothing' overall, plus per family for weapons, armor salvageables, trophies and materials
+Func BuildInventoryDerivedFlags()
+	Local $flags[]
+	For $path In MapKeys($loot_decisions)
+		Local $decision = $loot_decisions[$path]
+		Switch GetLootNodeKind($path)
+			Case $LOOT_KIND_ITEM
+				Local $parsed = ParseItemDecision($decision)
+				If $parsed['ignore'] Then ContinueLoop
+				Local $family = GetLootFamilyKey($path)
+				$flags['pickup'] = True
+				If $family <> '' Then $flags['pickup.' & $family] = True
+				If $parsed['identify'] Then $flags['identify'] = True
+				If $parsed['action'] == $LOOT_ACTION_KEEP Then ContinueLoop
+				$flags[$parsed['action']] = True
+				If $family <> '' Then $flags[$parsed['action'] & '.' & $family] = True
+				If $family == 'materials.basic' Or $family == 'materials.rare' Then $flags[$parsed['action'] & '.materials'] = True
+			Case $LOOT_KIND_MOD
+				; Salvaged mods are then stored or sold like any other item
+				Local $mod = ParseModDecision($decision)
+				If Not $mod['salvage'] Then ContinueLoop
+				$flags['components'] = True
+				Local $modAction = $mod['store'] ? $LOOT_ACTION_STORE : $LOOT_ACTION_SELL
+				$flags[$modAction] = True
+			Case $LOOT_KIND_BUY
+				If Not IsLootDecisionActive($path, $decision) Then ContinueLoop
+				$flags['buy'] = True
+				Local $family = GetLootFamilyKey($path)
+				If $family <> '' Then $flags['buy.' & $family] = True
+				If $family == 'materials.basic' Or $family == 'materials.rare' Then $flags['buy.materials'] = True
+		EndSwitch
+	Next
+
+	Local $names = ['pickup', 'pickup.weapons', 'identify', 'components', 'buy', 'buy.materials', 'buy.materials.basic', 'buy.materials.rare']
+	For $name In $names
+		SetInventoryDerivedFlag($name, MapExists($flags, $name))
+	Next
+	Local $families = ['weapons', 'salvageables', 'trophies', 'materials', 'materials.basic', 'materials.rare']
+	For $action In $LOOT_ACTIONS
+		If $action == $LOOT_ACTION_KEEP Then ContinueLoop
+		SetInventoryDerivedFlag($action, MapExists($flags, $action))
+		For $family In $families
+			SetInventoryDerivedFlag($action & '.' & $family, MapExists($flags, $action & '.' & $family))
+		Next
+	Next
+EndFunc
+
+
+;~ Write the '@name.something' and '@name.nothing' pair
+Func SetInventoryDerivedFlag($name, $value)
+	$inventory_management_cache['@' & $name & '.something'] = $value
+	$inventory_management_cache['@' & $name & '.nothing'] = Not $value
+EndFunc
+
+
+;~ Short family key of a leaf path for the derived flags, empty for families without flags
+Func GetLootFamilyKey($path)
+	Local $parts = StringSplit($path, '.')
+	If $parts[0] < 2 Then Return ''
+	Switch $parts[2]
+		Case $LOOT_WEAPONS_FAMILY
+			Return 'weapons'
+		Case $LOOT_ARMOR_FAMILY
+			Return 'salvageables'
+		Case $LOOT_TROPHIES_FAMILY
+			Return 'trophies'
+		Case $LOOT_BASIC_MATERIALS_FAMILY
+			Return 'materials.basic'
+		Case $LOOT_RARE_MATERIALS_FAMILY
+			Return 'materials.rare'
+	EndSwitch
+	Return ''
+EndFunc
+#EndRegion Derived flags
+
+
+#Region Migration from the previous format
+;~ Convert a configuration with one tree per action (Pick up items, Identify items, Salvage items, Sell items, Store items,
+;~ Keep components, Buy items) into the decisions per item format. Returns the new JSON object.
+;~ Picked up = not ignored. When several actions were ticked, salvage wins over sell, which wins over store.
+;~ Identification follows the rarity of weapons and armor salvageables, other items are not identifiable.
+Func MigrateLootConfigurationV1($old)
+	Local $flat[]
+	FlattenLootJsonV1($old, '', $flat)
+	Local $new[]
+	Local $items = $LOOT_ROOT_ITEMS & '.'
+
+	; ---------------------------------------- Money ----------------------------------------
+	AddMigratedItem($new, $items & $LOOT_MONEY, OldLootFlag($flat, 'Pick up items.Gold'), False, False, False, OldLootFlag($flat, 'Store items.Gold'))
+
+	; --------------------------------------- Weapons ---------------------------------------
+	Local $weapons = $items & $LOOT_WEAPONS_FAMILY & '.'
+	; The low requirement rule picked such weapons up whatever their leaf said, and the keep rules stored them
+	AddMigratedItem($new, $weapons & $LOOT_LOW_REQ_RULE, OldLootFlag($flat, 'Pick up items.Weapons and offhands.Low Req Max Stats'), True, False, False, True)
+	For $type In $LOOT_WEAPON_TYPE_NAMES
+		For $rarity In $LOOT_WEAPON_RARITY_NAMES
+			Local $identify = OldLootFlag($flat, 'Identify items.' & $rarity)
+			For $req = 0 To $LOOT_WEAPON_MAX_REQ
+				Local $oldSuffix = '.Weapons and offhands.' & $rarity & '.' & $type & '.Req ' & $req
+				Local $pickup	= OldLootFlag($flat, 'Pick up items' & $oldSuffix)
+				Local $salvage	= OldLootFlag($flat, 'Salvage items' & $oldSuffix)
+				Local $sell		= OldLootFlag($flat, 'Sell items' & $oldSuffix)
+				Local $store	= OldLootFlag($flat, 'Store items' & $oldSuffix)
+				Local $newPrefix = $weapons & $type & '.' & $rarity & '.Req ' & $req & '.'
+				AddMigratedItem($new, $newPrefix & $LOOT_RARE_SKINS, $pickup, $identify, $salvage, $sell, $store)
+				AddMigratedItem($new, $newPrefix & $LOOT_OTHER_SKINS, $pickup, $identify, $salvage, $sell, $store)
+			Next
+		Next
+		; Green weapons have no requirement choice: one leaf per type, active when any requirement was
+		Local $greenPickup = False, $greenSalvage = False, $greenSell = False, $greenStore = False
+		For $req = 0 To $LOOT_WEAPON_MAX_REQ
+			Local $oldSuffix = '.Weapons and offhands.' & $LOOT_GREEN_RARITY & '.' & $type & '.Req ' & $req
+			If OldLootFlag($flat, 'Pick up items' & $oldSuffix) Then $greenPickup = True
+			If OldLootFlag($flat, 'Salvage items' & $oldSuffix) Then $greenSalvage = True
+			If OldLootFlag($flat, 'Sell items' & $oldSuffix) Then $greenSell = True
+			If OldLootFlag($flat, 'Store items' & $oldSuffix) Then $greenStore = True
+		Next
+		AddMigratedItem($new, $weapons & $type & '.' & $LOOT_GREEN_RARITY, $greenPickup, OldLootFlag($flat, 'Identify items.' & $LOOT_GREEN_RARITY), $greenSalvage, $greenSell, $greenStore)
+	Next
+
+	; --------------------------------- Armor salvageables ---------------------------------
+	For $rarity In $LOOT_WEAPON_RARITY_NAMES
+		Local $oldSuffix = '.Armor salvageables.' & $rarity
+		AddMigratedItem($new, $items & $LOOT_ARMOR_FAMILY & '.' & $rarity, OldLootFlag($flat, 'Pick up items' & $oldSuffix), OldLootFlag($flat, 'Identify items.' & $rarity), _
+			OldLootFlag($flat, 'Salvage items' & $oldSuffix), OldLootFlag($flat, 'Sell items' & $oldSuffix), OldLootFlag($flat, 'Store items' & $oldSuffix))
+	Next
+
+	; --------------------------------------- Trophies ---------------------------------------
+	Local $trophies = $items & $LOOT_TROPHIES_FAMILY & '.'
+	For $name In OldLootGroupKeys($old, 'Pick up items.Trophies')
+		If $name == $LOOT_TROPHIES_OTHER Then ContinueLoop
+		Local $oldSuffix = '.Trophies.' & $name
+		AddMigratedItem($new, $trophies & $name, OldLootFlag($flat, 'Pick up items' & $oldSuffix), False, _
+			OldLootFlag($flat, 'Salvage items' & $oldSuffix), OldLootFlag($flat, 'Sell items' & $oldSuffix), OldLootFlag($flat, 'Store items' & $oldSuffix))
+	Next
+	; Trophies without their own entry: the previous rules salvaged the ones giving common materials when any trophy salvage was ticked,
+	; never touched Nicholas and rare material trophies, and sold the rest when anything at all was sold
+	Local $otherTrophiesPickup = OldLootFlag($flat, 'Pick up items.Trophies.Other trophies')
+	AddMigratedItem($new, $trophies & $LOOT_TROPHIES_COMMON_MATERIALS, $otherTrophiesPickup, False, OldLootAnyFlag($flat, 'Salvage items.Trophies'), False, False)
+	AddMigratedItem($new, $trophies & $LOOT_TROPHIES_NICHOLAS, $otherTrophiesPickup, False, False, False, False)
+	AddMigratedItem($new, $trophies & $LOOT_TROPHIES_RARE_MATERIALS, $otherTrophiesPickup, False, False, False, False)
+	AddMigratedItem($new, $trophies & $LOOT_TROPHIES_OTHER, $otherTrophiesPickup, False, False, OldLootAnyFlag($flat, 'Sell items'), False)
+
+	; -------------------------------------- Materials --------------------------------------
+	For $name In OldLootGroupKeys($old, 'Pick up items.Basic Materials')
+		Local $oldSuffix = '.Basic Materials.' & $name
+		AddMigratedItem($new, $items & $LOOT_BASIC_MATERIALS_FAMILY & '.' & $name, OldLootFlag($flat, 'Pick up items' & $oldSuffix), False, _
+			False, OldLootFlag($flat, 'Sell items' & $oldSuffix), OldLootFlag($flat, 'Store items' & $oldSuffix))
+	Next
+	For $name In OldLootGroupKeys($old, 'Pick up items.Rare Materials')
+		Local $oldSuffix = '.Rare Materials.' & $name
+		AddMigratedItem($new, $items & $LOOT_RARE_MATERIALS_FAMILY & '.' & $name, OldLootFlag($flat, 'Pick up items' & $oldSuffix), False, _
+			OldLootFlag($flat, 'Salvage items' & $oldSuffix), OldLootFlag($flat, 'Sell items' & $oldSuffix), OldLootFlag($flat, 'Store items' & $oldSuffix))
+	Next
+
+	; ------------------------------------- Consumables -------------------------------------
+	Local $pickupConsumables = OldLootFlag($flat, 'Pick up items.Consumables')
+	AddMigratedItem($new, $items & $LOOT_CONSUMABLES, $pickupConsumables, False, False, False, OldLootFlag($flat, 'Store items.Consumables'))
+	Local $consumableFamilies = ['Alcohols', 'Party', 'Sweets', 'PCons', 'Morale', 'Special drops']
+	For $family In $consumableFamilies
+		For $name In OldLootGroupKeys($old, 'Pick up items.' & $family)
+			Local $oldSuffix = '.' & $family & '.' & $name
+			AddMigratedItem($new, $items & $family & '.' & $name, OldLootFlag($flat, 'Pick up items' & $oldSuffix), False, False, False, OldLootFlag($flat, 'Store items' & $oldSuffix))
+		Next
+	Next
+	; Consets and summoning stones were only listed for storage and picked up as consumables
+	Local $storedFamilies = ['Consets', 'Summoning stones']
+	For $family In $storedFamilies
+		For $name In OldLootGroupKeys($old, 'Store items.' & $family)
+			AddMigratedItem($new, $items & $family & '.' & $name, $pickupConsumables, False, False, False, OldLootFlag($flat, 'Store items.' & $family & '.' & $name))
+		Next
+	Next
+
+	; ----------------------------------------- Tomes -----------------------------------------
+	Local $tomeKinds = ['Normal', 'Elite']
+	For $kind In $tomeKinds
+		For $name In OldLootGroupKeys($old, 'Pick up items.Tomes.' & $kind)
+			Local $oldSuffix = '.Tomes.' & $kind & '.' & $name
+			AddMigratedItem($new, $items & 'Tomes.' & $kind & '.' & $name, OldLootFlag($flat, 'Pick up items' & $oldSuffix), False, False, False, OldLootFlag($flat, 'Store items' & $oldSuffix))
+		Next
+	Next
+
+	; ---------------------------------------- Scrolls ----------------------------------------
+	AddMigratedItem($new, $items & $LOOT_SCROLLS_FAMILY & '.Blue', OldLootFlag($flat, 'Pick up items.Scrolls.Blue'), False, False, OldLootFlag($flat, 'Sell items.Scrolls.Blue'), OldLootFlag($flat, 'Store items.Scrolls.Blue'))
+	For $name In OldLootGroupKeys($old, 'Pick up items.Scrolls.Gold')
+		Local $oldSuffix = '.Scrolls.Gold.' & $name
+		AddMigratedItem($new, $items & $LOOT_SCROLLS_FAMILY & '.Gold.' & $name, OldLootFlag($flat, 'Pick up items' & $oldSuffix), False, False, OldLootFlag($flat, 'Sell items' & $oldSuffix), OldLootFlag($flat, 'Store items' & $oldSuffix))
+	Next
+
+	; ----------------------------------------- Dyes ------------------------------------------
+	For $name In OldLootGroupKeys($old, 'Pick up items.Dyes')
+		AddMigratedItem($new, $items & 'Dyes.' & $name, OldLootFlag($flat, 'Pick up items.Dyes.' & $name), False, False, False, OldLootFlag($flat, 'Store items.Dyes.' & $name))
+	Next
+
+	; ------------------------------------ Keys and others ------------------------------------
+	AddMigratedItem($new, $items & 'Keys', OldLootFlag($flat, 'Pick up items.Keys'), False, False, OldLootFlag($flat, 'Sell items.Keys'), OldLootFlag($flat, 'Store items.Keys'))
+	AddMigratedItem($new, $items & 'Lockpicks', OldLootFlag($flat, 'Pick up items.Lockpicks'), False, False, False, OldLootFlag($flat, 'Store items.Lockpicks'))
+	AddMigratedItem($new, $items & 'Miniatures', OldLootFlag($flat, 'Pick up items.Miniatures'), False, False, False, False)
+	AddMigratedItem($new, $items & 'Quest items.Map pieces', OldLootFlag($flat, 'Pick up items.Quest items.Map pieces'), False, False, False, False)
+	; Stackables without their own entry were picked up, anything else was left on the ground
+	AddMigratedItem($new, $items & $LOOT_OTHER_FAMILY & '.' & $LOOT_OTHER_STACKABLES, True, False, False, False, False)
+	AddMigratedItem($new, $items & $LOOT_OTHER_FAMILY & '.' & $LOOT_OTHER_UNKNOWN, False, False, False, False, False)
+
+	; ----------------------------------------- Mods ------------------------------------------
+	; Kept components become salvaged components, stored unless upgrade components were not stored
+	Local $storeComponents = Not MapExists($flat, 'Store items.Upgrade components') Or OldLootFlag($flat, 'Store items.Upgrade components')
+	Local $oldComponentsPrefix = 'Keep components.'
+	For $path In MapKeys($flat)
+		If StringLeft($path, StringLen($oldComponentsPrefix)) <> $oldComponentsPrefix Then ContinueLoop
+		If Not IsLootLeafPathV1($flat, $path) Then ContinueLoop
+		Local $newPath = StringTrimLeft($path, StringLen($oldComponentsPrefix))
+		; 'Keep components.Mods' held the weapon mods, next to inscriptions and armor upgrades
+		If StringLeft($newPath, 5) == 'Mods.' Then $newPath = $LOOT_WEAPON_MODS_GROUP & StringTrimLeft($newPath, 4)
+		_JSON_addChangeDelete($new, $LOOT_ROOT_MODS & '.' & $newPath, FormatModDecision($flat[$path], $storeComponents))
+	Next
+
+	; --------------------------------------- Buy items ---------------------------------------
+	Local $oldBuyPrefix = $LOOT_ROOT_BUY & '.'
+	For $path In MapKeys($flat)
+		If StringLeft($path, StringLen($oldBuyPrefix)) <> $oldBuyPrefix Then ContinueLoop
+		If Not IsLootLeafPathV1($flat, $path) Then ContinueLoop
+		_JSON_addChangeDelete($new, $path, $flat[$path] == True)
+	Next
+	Return $new
+EndFunc
+
+
+;~ Add one migrated item leaf - salvage wins over sell, which wins over store, identification needs the item to be picked up
+Func AddMigratedItem(ByRef $json, $path, $pickup, $identify, $salvage, $sell, $store)
+	Local $action = $LOOT_ACTION_KEEP
+	If $salvage Then
+		$action = $LOOT_ACTION_SALVAGE
+	ElseIf $sell Then
+		$action = $LOOT_ACTION_SELL
+	ElseIf $store Then
+		$action = $LOOT_ACTION_STORE
+	EndIf
+	_JSON_addChangeDelete($json, $path, FormatItemDecision(Not $pickup, $identify And $pickup, $action))
+EndFunc
+
+
+;~ Flatten a previous format configuration into path -> boolean, groups being True when all their leaves are
+Func FlattenLootJsonV1($node, $path, ByRef $flat)
+	If IsMap($node) Then
+		Local $all = True
+		For $key In MapKeys($node)
+			If Not FlattenLootJsonV1($node[$key], ($path == '' ? $key : $path & '.' & $key), $flat) Then $all = False
+		Next
+		If $path <> '' Then $flat[$path] = $all
+		Return $all
+	EndIf
+	$flat[$path] = ($node == True)
+	Return $node == True
+EndFunc
+
+
+;~ Value of a previous format flag, False when it did not exist
+Func OldLootFlag(ByRef $flat, $path)
+	If Not MapExists($flat, $path) Then Return False
+	Return $flat[$path] == True
+EndFunc
+
+
+;~ True when any leaf below the path was ticked in a previous format configuration
+Func OldLootAnyFlag(ByRef $flat, $path)
+	Local $prefix = $path & '.'
+	For $key In MapKeys($flat)
+		If StringLeft($key, StringLen($prefix)) == $prefix And $flat[$key] == True Then Return True
+	Next
+	Return False
+EndFunc
+
+
+;~ True when the path is a leaf of the flattened previous format configuration
+Func IsLootLeafPathV1(ByRef $flat, $path)
+	Local $prefix = $path & '.'
+	For $key In MapKeys($flat)
+		If StringLeft($key, StringLen($prefix)) == $prefix Then Return False
+	Next
+	Return True
+EndFunc
+
+
+;~ Keys of a group of a previous format configuration, in file order - empty when the group does not exist
+Func OldLootGroupKeys($old, $path)
+	Local $none[0]
+	Local $node = _JSON_Get($old, $path)
+	If @error Or Not IsMap($node) Then Return $none
+	Return MapKeys($node)
+EndFunc
+#EndRegion Migration from the previous format

--- a/lib/Utils-Storage.au3
+++ b/lib/Utils-Storage.au3
@@ -45,12 +45,13 @@ Func InventoryManagementBeforeRun()
 	; 2-Sort items
 	; 3-Identify items
 	; 4-Collect data
-	; 5-Salvage
-	; 6-Sell materials
-	; 7-Sell items
-	; 8-Balance character gold level
-	; 9-Buy ectoplasm/obsidian with surplus
-	; 10-Store items
+	; 5-Salvage valuable components out of items not worth keeping
+	; 6-Salvage
+	; 7-Sell materials
+	; 8-Sell items
+	; 9-Balance character gold level
+	; 10-Buy ectoplasm/obsidian with surplus
+	; 11-Store items
 	If $cache['Store items.Unidentified gold items'] And HasGoldUnidentifiedItems() Then
 		If GetMapType() <> $ID_OUTPOST Then TravelToOutpost($trade_town, $district_name)
 		StoreItemsInXunlaiStorage(IsUnidentifiedGoldItem)
@@ -68,11 +69,14 @@ Func InventoryManagementBeforeRun()
 		StoreAllItemsData()
 		DisconnectFromDatabase()
 	EndIf
+	If $run_options_cache['run.salvage_into_components'] And HasComponentsToSalvage() Then
+		TravelToOutpost($trade_town, $district_name)
+		SalvageComponents()
+	EndIf
 	If $cache['@salvage.something'] And HasItemsToSalvage() Then
 		TravelToOutpost($trade_town, $district_name)
 		SalvageItems()
 		If $bags_count == 5 And MoveItemsOutOfEquipmentBag() > 0 Then SalvageItems()
-		;SalvageInscriptions()
 		;UpgradeWithSalvageInscriptions()
 		;SalvageMaterials()
 	EndIf
@@ -123,7 +127,8 @@ Func InventoryManagementMidRun()
 	; 2-If not, buy until we have 4 identification kits and 12 salvaged kits
 	; 3-Sort items
 	; 4-Identify items
-	; 5-Salvage
+	; 5-Salvage valuable components out of items if an expert salvage kit is available
+	; 6-Salvage
 	Local Static $superiorIdentificationKits = [$ID_INFINITE_IDENTIFICATION_KIT, $ID_SUPERIOR_IDENTIFICATION_KIT]
 	Local Static $salvageKits = [$ID_SALVAGE_KIT, $ID_SALVAGE_KIT_2]
 	If GetInventoryKitCount($superiorIdentificationKits) < 1 Or GetInventoryKitCount($salvageKits) < 1 Then
@@ -136,6 +141,7 @@ Func InventoryManagementMidRun()
 	EndIf
 	If $run_options_cache['run.sort_items'] Then SortInventory()
 	If $inventory_management_cache['@identify.something'] And HasUnidentifiedItems() Then IdentifyItems(False)
+	If $run_options_cache['run.salvage_into_components'] Then SalvageComponents(False)
 	If $inventory_management_cache['@salvage.something'] Then
 		SalvageItems(False)
 		If $bags_count == 5 And MoveItemsOutOfEquipmentBag() > 0 Then SalvageItems(False)
@@ -466,6 +472,22 @@ Func DefaultShouldSalvageItem($item)
 EndFunc
 
 
+;~ Return True if valuable components (mods, inscriptions, runes, insignias) should be salvaged out of the item
+;~ Only items not worth keeping for themselves are stripped, so weapons kept for their skin, req or stats stay untouched
+Func ShouldSalvageComponents($item)
+	If DllStructGetData($item, 'ID') = 0 Then Return False
+	If GetRarity($item) == $RARITY_GREEN Then Return False
+	If Not IsIdentified($item) Then Return False
+	If IsWeapon($item) Then
+		If Not DllStructGetData($item, 'IsMaterialSalvageable') Then Return False
+		If ShouldKeepWeapon($item, False) Then Return False
+	ElseIf Not IsArmorSalvageItem($item) Then
+		Return False
+	EndIf
+	Return UBound(GetValuableComponentIndices($item)) > 0
+EndFunc
+
+
 ;~ Return True if the item should be sold to the merchant - default to false
 Func DefaultShouldSellItem($item)
 	; Clarity rename
@@ -541,6 +563,11 @@ Func DefaultShouldStoreItem($item)
 		Local $rarityName = $RARITY_NAMES_FROM_IDS[$rarity]
 		;Return ContainsValuableUpgrades($item)
 		Return $cache['Store items.Armor salvageables.' & $rarityName]
+	; ----------------------------------- Upgrade components -----------------------------------
+	ElseIf IsUpgradeComponent($item) Then
+		Local $shouldStore = $cache['Store items.Upgrade components']
+		; Loot configurations saved before this option existed have no value for it: store components when the bot salvages them
+		Return $shouldStore == Null ? $run_options_cache['run.salvage_into_components'] : $shouldStore
 	; ------------------------------------- Consumables -------------------------------------
 	ElseIf IsAlcohol($itemID) Then
 		If $MAP_MINOR_ALCOHOLS[$itemID] <> Null Then Return $cache['Store items.Alcohols.Minor (1pt)']
@@ -614,8 +641,8 @@ Func DefaultShouldStoreItem($item)
 EndFunc
 
 
-;~ Return True if weapon item should not be sold or salvaged
-Func ShouldKeepWeapon($item)
+;~ Return True if weapon item should not be sold or salvaged - $checkUpgrades False ignores the components it contains
+Func ShouldKeepWeapon($item, $checkUpgrades = True)
 	Local Static $lowReqValuableWeaponTypes = [$ID_TYPE_SWORD, $ID_TYPE_OFFHAND, $ID_TYPE_SHIELD, $ID_TYPE_DAGGER, $ID_TYPE_SCYTHE, $ID_TYPE_SPEAR]
 	Local Static $lowReqValuableWeaponTypesMap = MapFromArray($lowReqValuableWeaponTypes)
 	Local Static $valuableOSWeaponTypes = [$ID_TYPE_SHIELD, $ID_TYPE_OFFHAND, $ID_TYPE_WAND]
@@ -637,7 +664,7 @@ Func ShouldKeepWeapon($item)
 	; Keeping super-rare items, good in all cases, items (BDS, voltaic, etc)
 	If $MAP_ULTRA_RARE_WEAPONS[$itemID] <> Null Then Return True
 	; Keeping items that contain good upgrades
-	If ContainsValuableUpgrades($item) Then Return True
+	If $checkUpgrades And ContainsValuableUpgrades($item) Then Return True
 	; Throwing items without good damage/energy/armor
 	If Not IsMaxStatsForReq($item) Then Return False
 	; Inscribable are kept only if : 1) rare skin and q9 2) low Req of a good type
@@ -1045,6 +1072,8 @@ Func BuyKitsForMidRun()
 
 	If $salvageKitsRequired > 0 Then BuySalvageKitInTown($salvageKitsRequired)
 	If $identificationKitsRequired > 0 Then BuySuperiorIdentificationKitInTown($identificationKitsRequired)
+	; Salvaging components needs an expert salvage kit - keep one in inventory when the option is enabled
+	If $run_options_cache['run.salvage_into_components'] And FindSalvageKit() == Null Then BuyExpertSalvageKitInTown()
 EndFunc
 #EndRegion Buying/selling items from/to merchant
 
@@ -1328,6 +1357,31 @@ Func GetSalvageKit($buyKit = True)
 EndFunc
 
 
+;~ Returns an expert or superior salvage kit, buying an expert one in town if needed and allowed - required to salvage components
+Func GetExpertSalvageKit($buyKit = True)
+	Local $kit = FindSalvageKit()
+	If $kit == Null And $buyKit Then
+		BuyExpertSalvageKitInTown()
+		$kit = FindSalvageKit()
+	EndIf
+	Return $kit
+EndFunc
+
+
+;~ Returns the remaining uses of a salvage kit - kits sell back for a fixed price per remaining use
+Func GetSalvageKitUses($kit)
+	Local $value = DllStructGetData($kit, 'Value')
+	Switch DllStructGetData($kit, 'ModelID')
+		Case $ID_EXPERT_SALVAGE_KIT
+			Return $value / 8
+		Case $ID_SUPERIOR_SALVAGE_KIT
+			Return $value / 10
+		Case Else
+			Return $value / 2
+	EndSwitch
+EndFunc
+
+
 ;~ Salvage an item based on its position in the inventory
 Func SalvageItemAt($bagIndex, $slot)
 	Local $item = GetItemBySlot($bagIndex, $slot)
@@ -1362,6 +1416,88 @@ Func SalvageItem($item, $salvageKit, $salvageType = 'Materials')
 			Return False
 	EndSwitch
 	PingSleep(50)
+	Return True
+EndFunc
+
+
+;~ Salvage valuable components (mods, inscriptions, runes, insignias) out of the items not worth keeping for themselves
+;~ Needs an expert or superior salvage kit - the stripped item then goes through the usual salvage/sell flow
+;~ Salvaging a component can destroy the item, so it is re-read from its slot after each salvage
+;~ With $dryRun, only logs what would be salvaged
+Func SalvageComponents($buyKit = True, $dryRun = False)
+	; A weapon holds at most a prefix, a suffix and an inscription
+	Local Static $maxComponentsPerItem = 3
+	Info('Salvaging components out of items')
+	Local $kit = Null
+	Local $uses = 0
+	If Not $dryRun Then
+		$kit = GetExpertSalvageKit($buyKit)
+		If $kit == Null Then
+			Warn('No expert salvage kit available to salvage components')
+			Return False
+		EndIf
+		$uses = GetSalvageKitUses($kit)
+	EndIf
+
+	For $bagIndex = 1 To $bags_count
+		Local $bagSize = DllStructGetData(GetBag($bagIndex), 'slots')
+		For $slot = 1 To $bagSize
+			Local $item = GetItemBySlot($bagIndex, $slot)
+			If Not ShouldSalvageComponents($item) Then ContinueLoop
+			Local $itemID = DllStructGetData($item, 'ID')
+			Local $attempts = 0
+			While $attempts < $maxComponentsPerItem
+				Local $indices = GetValuableComponentIndices($item)
+				If UBound($indices) == 0 Then ExitLoop
+				If $dryRun Then
+					Info('Would salvage components ' & _ArrayToString($indices, ', ') & ' out of item at ' & $bagIndex & ':' & $slot)
+					ExitLoop
+				EndIf
+				; Each salvaged component needs a free slot, and the item may survive the salvage
+				If CountSlots(1, _Min(4, $bags_count)) < 1 Then
+					Warn('No space left in inventory to salvage more components')
+					Return True
+				EndIf
+				Debug('Salvaging component ' & $indices[0] & ' out of item at ' & $bagIndex & ':' & $slot)
+				Local $modStructBefore = GetModStruct($item)
+				SalvageComponent($item, $kit, $indices[0])
+				$attempts += 1
+				$uses -= 1
+				If $uses < 1 Then
+					$kit = GetExpertSalvageKit($buyKit)
+					If $kit == Null Then Return False
+					$uses = GetSalvageKitUses($kit)
+				EndIf
+				; The salvage might have destroyed the item - stop if it is gone or replaced
+				$item = GetItemBySlot($bagIndex, $slot)
+				If DllStructGetData($item, 'ID') <> $itemID Then ExitLoop
+				If GetModStruct($item) == $modStructBefore Then
+					Warn('Salvaging a component did not change the item at ' & $bagIndex & ':' & $slot & ', skipping it')
+					ExitLoop
+				EndIf
+			WEnd
+		Next
+	Next
+	Return True
+EndFunc
+
+
+;~ Salvage the component at the given index (prefix/insignia 0, suffix/rune 1, inscription 2) out of the given item
+;~ Needs an expert or superior salvage kit: the game opens a choice window for those, and the packets answer it directly
+Func SalvageComponent($item, $salvageKit, $componentIndex)
+	Local $rarity = GetRarity($item)
+	While Not StartSalvageWithKit($item, $salvageKit)
+		PingSleep(50)
+	WEnd
+	PingSleep(600)
+	If $rarity == $RARITY_GOLD Or $rarity == $RARITY_PURPLE Then
+		ValidateSalvage()
+		PingSleep(600)
+	EndIf
+	SalvageMod($componentIndex)
+	PingSleep(600)
+	EndSalvage()
+	PingSleep(300)
 	Return True
 EndFunc
 #EndRegion Salvage
@@ -1789,6 +1925,12 @@ EndFunc
 ;~ Returns true if there are items in inventory that user selected to salvage in the GUI interface
 Func HasItemsToSalvage($shouldSalvageItem = DefaultShouldSalvageItem)
 	Return HasInInventory($shouldSalvageItem)
+EndFunc
+
+
+;~ Returns true if there are items in inventory with valuable components to salvage out
+Func HasComponentsToSalvage()
+	Return HasInInventory(ShouldSalvageComponents)
 EndFunc
 
 
@@ -2394,6 +2536,12 @@ EndFunc
 ;~ Return true if the item is a weapon mod
 Func IsWeaponMod($itemID)
 	Return $MAP_WEAPON_MODS[$itemID] <> Null
+EndFunc
+
+
+;~ Return true if the item is an upgrade component: weapon mod, inscription, rune or insignia
+Func IsUpgradeComponent($item)
+	Return DllStructGetData($item, 'type') == $ID_TYPE_UPGRADE
 EndFunc
 
 

--- a/lib/Utils-Storage.au3
+++ b/lib/Utils-Storage.au3
@@ -36,28 +36,23 @@ Global $trade_town = $ID_EYE_OF_THE_NORTH
 
 
 #Region Inventory Management
-;~ Function to deal with inventory before farm run
+;~ Inventory management before a run: identify, salvage mods, salvage, sell, balance gold, buy and store - in that order
 Func InventoryManagementBeforeRun()
 	; Clarity rename
 	Local $cache = $inventory_management_cache
 	; Operations order :
-	; 1-Store unids if desired
-	; 2-Sort items
-	; 3-Identify items
-	; 4-Collect data
-	; 5-Salvage valuable components out of items not worth keeping
-	; 6-Salvage
-	; 7-Sell materials
-	; 8-Sell items
-	; 9-Balance character gold level
-	; 10-Buy ectoplasm/obsidian with surplus
-	; 11-Store items
-	If $cache['Store items.Unidentified gold items'] And HasGoldUnidentifiedItems() Then
-		If GetMapType() <> $ID_OUTPOST Then TravelToOutpost($trade_town, $district_name)
-		StoreItemsInXunlaiStorage(IsUnidentifiedGoldItem)
-	EndIf
+	; 1-Sort items
+	; 2-Identify items
+	; 3-Collect data
+	; 4-Salvage mods out of items that are salvaged or sold
+	; 5-Salvage
+	; 6-Sell materials
+	; 7-Sell items
+	; 8-Balance character gold level
+	; 9-Buy ectoplasm/obsidian with surplus
+	; 10-Store items
 	If $run_options_cache['run.sort_items'] Then SortInventory()
-	If $cache['@identify.something'] And HasUnidentifiedItems() Then
+	If $cache['@identify.something'] And HasItemsToIdentify() Then
 		TravelToOutpost($trade_town, $district_name)
 		IdentifyItems()
 	EndIf
@@ -69,7 +64,7 @@ Func InventoryManagementBeforeRun()
 		StoreAllItemsData()
 		DisconnectFromDatabase()
 	EndIf
-	If $run_options_cache['run.salvage_into_components'] And HasComponentsToSalvage() Then
+	If $cache['@components.something'] And HasComponentsToSalvage() Then
 		TravelToOutpost($trade_town, $district_name)
 		SalvageComponents()
 	EndIf
@@ -77,6 +72,7 @@ Func InventoryManagementBeforeRun()
 		TravelToOutpost($trade_town, $district_name)
 		SalvageItems()
 		If $bags_count == 5 And MoveItemsOutOfEquipmentBag() > 0 Then SalvageItems()
+		;SalvageInscriptions()
 		;UpgradeWithSalvageInscriptions()
 		;SalvageMaterials()
 	EndIf
@@ -94,7 +90,7 @@ Func InventoryManagementBeforeRun()
 		SellItemsToMerchant()
 	EndIf
 	; Max gold in Xunlai chest is 1000 platinums
-	If $cache['Store items.Gold'] Then
+	If IsMoneyStored() Then
 		If GetMapType() <> $ID_OUTPOST Then TravelToOutpost($trade_town, $district_name)
 		BalanceCharacterGold(10000)
 	EndIf
@@ -127,7 +123,7 @@ Func InventoryManagementMidRun()
 	; 2-If not, buy until we have 4 identification kits and 12 salvaged kits
 	; 3-Sort items
 	; 4-Identify items
-	; 5-Salvage valuable components out of items if an expert salvage kit is available
+	; 5-Salvage mods out of items that are salvaged or sold
 	; 6-Salvage
 	Local Static $superiorIdentificationKits = [$ID_INFINITE_IDENTIFICATION_KIT, $ID_SUPERIOR_IDENTIFICATION_KIT]
 	Local Static $salvageKits = [$ID_SALVAGE_KIT, $ID_SALVAGE_KIT_2]
@@ -140,8 +136,8 @@ Func InventoryManagementMidRun()
 		Return True
 	EndIf
 	If $run_options_cache['run.sort_items'] Then SortInventory()
-	If $inventory_management_cache['@identify.something'] And HasUnidentifiedItems() Then IdentifyItems(False)
-	If $run_options_cache['run.salvage_into_components'] Then SalvageComponents(False)
+	If $inventory_management_cache['@identify.something'] And HasItemsToIdentify() Then IdentifyItems(False)
+	If $inventory_management_cache['@components.something'] Then SalvageComponents(False)
 	If $inventory_management_cache['@salvage.something'] Then
 		SalvageItems(False)
 		If $bags_count == 5 And MoveItemsOutOfEquipmentBag() > 0 Then SalvageItems(False)
@@ -329,436 +325,104 @@ EndFunc
 
 ;~ Return True if the item should be picked up - default to False
 Func DefaultShouldPickItem($item)
-	; Clarity rename
-	Local $cache = $inventory_management_cache
-	If $cache['@pickup.nothing'] Then Return False
-	If $cache['@pickup.everything'] Then Return True
-
-	Local $itemID = DllStructGetData(($item), 'ModelID')
-	Local $rarity = GetRarity($item)
-
-	; ---------------------------------------- Money ----------------------------------------
-	If (($itemID == $ID_MONEY) And (GetGoldCharacter() < 99000)) Then
-		Return $cache['Pick up items.Gold']
-	; --------------------------------------- Weapons ---------------------------------------
-	ElseIf IsWeapon($item) Then
-		Return CheckPickupWeapon($item)
-	; --------------------------------- Armor salvageables ---------------------------------
-	ElseIf isArmorSalvageItem($item) Then
-		Local $rarityName = $RARITY_NAMES_FROM_IDS[$rarity]
-		Return $cache['Pick up items.Armor salvageables.' & $rarityName]
-	; --------------------------- Consumables, Alcohols, Party & Sweets ---------------------------
-	ElseIf IsAlcohol($itemID) Then
-		If $MAP_MINOR_ALCOHOLS[$itemID] <> Null Then Return $cache['Pick up items.Alcohols.Minor (1pt)']
-		If $MAP_MAJOR_ALCOHOLS[$itemID] <> Null Then Return $cache['Pick up items.Alcohols.Major (3pt)']
-		If $MAP_SUPERIOR_ALCOHOLS[$itemID] <> Null Then Return $cache['Pick up items.Alcohols.Superior (50pt)']
-		Return False
-	ElseIf IsFestive($itemID) Or IsPartyTonic($itemID) Then
-		If $MAP_MINOR_PARTY[$itemID] <> Null Then Return $cache['Pick up items.Party.Minor (1-2pt)']
-		If $MAP_MAJOR_PARTY[$itemID] <> Null Then Return $cache['Pick up items.Party.Major (3-7pt)']
-		If $MAP_SUPERIOR_PARTY[$itemID] <> Null Then Return $cache['Pick up items.Party.Superior (25-50pt)']
-		Return False
-	ElseIf IsTownSweet($itemID) Then
-		If $MAP_MINOR_SWEETS[$itemID] <> Null Then Return $cache['Pick up items.Sweets.Minor (1-2pt)']
-		If $MAP_MAJOR_SWEETS[$itemID] <> Null Then Return $cache['Pick up items.Sweets.Major (3pt)']
-		If $MAP_SUPERIOR_SWEETS[$itemID] <> Null Then Return $cache['Pick up items.Sweets.Superior (50pt)']
-		Return False
-	ElseIf IsPCon($itemID) Then
-		Local $pconName = $PCONS_NAMES_FROM_IDS[$itemID]
-		Return $cache['Pick up items.PCons.' & $pconName]
-	ElseIf IsDPRemoval($itemID) Then
-		Local $moraleItemName = $DP_REMOVAL_NAMES_FROM_IDS[$itemID]
-		Return $cache['Pick up items.Morale.' & $moraleItemName]
-	ElseIf IsSpecialDrop($itemID) Then
-		Local $specialDropName = $SPECIAL_DROP_NAMES_FROM_IDS[$itemID]
-		Return $cache['Pick up items.Special drops.' & $specialDropName]
-	ElseIf IsConsumable($itemID) Then
-		Return $cache['Pick up items.Consumables']
-	; --------------------------------------- Trophies ---------------------------------------
-	ElseIf IsTrophy($itemID) Then
-		If $MAP_FARMED_TROPHIES[$itemID] <> Null Then Return $cache['Pick up items.Trophies.' & $FARMED_TROPHIES_NAMES_FROM_ID[$itemID]]
-		Return $cache['Pick up items.Trophies.Other trophies']
-	; -------------------------------------- Materials --------------------------------------
-	ElseIf IsBasicMaterial($item) Then
-		Local $materialName = $BASIC_MATERIAL_NAMES_FROM_IDS[$itemID]
-		Return $cache['Pick up items.Basic Materials.' & $materialName]
-	ElseIf IsRareMaterial($item) Then
-		Local $materialName = $RARE_MATERIAL_NAMES_FROM_IDS[$itemID]
-		Return $cache['Pick up items.Rare Materials.' & $materialName]
-	; ---------------------------------------- Tomes ----------------------------------------
-	ElseIf IsRegularTome($itemID) Then
-		Local $tomeName = $REGULAR_TOME_NAMES_FROM_IDS[$itemID]
-		Return $cache['Pick up items.Tomes.Normal.' & $tomeName]
-	ElseIf IsEliteTome($itemID) Then
-		Local $tomeName = $ELITE_TOME_NAMES_FROM_IDS[$itemID]
-		Return $cache['Pick up items.Tomes.Elite.' & $tomeName]
-	; --------------------------------------- Scrolls ---------------------------------------
-	ElseIf IsGoldScroll($itemID) Then
-		Local $scrollName = $GOLD_SCROLL_NAMES_FROM_IDS[$itemID]
-		Local $pickup = $cache['Pick up items.Scrolls.Gold.' & $scrollName]
-		If $pickup <> Null Then Return $pickup
-		Return $cache['Pick up items.Scrolls.Gold.Other gold scrolls']
-	ElseIf IsBlueScroll($itemID) Then
-		Return $cache['Pick up items.Scrolls.Blue']
-	; ----------------------------------------- Keys -----------------------------------------
-	ElseIf IsKey($itemID) Then
-		Return $cache['Pick up items.Keys']
-	ElseIf ($itemID == $ID_LOCKPICK) Then
-		Return $cache['Pick up items.Lockpicks']
-	; ----------------------------------------- Dyes -----------------------------------------
-	ElseIf ($itemID == $ID_DYES) Then
-		Local $dyeColorID = DllStructGetData($item, 'DyeColor')
-		Local $dyeColorName = $DYE_NAMES_FROM_IDS[$dyeColorID]
-		Return $cache['Pick up items.Dyes.' & $dyeColorName]
-	; --------------------------------- Gizmos & Quest items ---------------------------------
-	ElseIf ($itemID == $ID_JAR_OF_INVIGORATION) Then
-		Return False
-	ElseIf IsMapPiece($itemID) Then
-		Return $cache['Pick up items.Quest items.Map pieces']
-	ElseIf IsMiniature($item) Then
-		Return $cache['Pick up items.Miniatures']
-	; ----------------------------------- Other stackables -----------------------------------
-	ElseIf IsStackable($item) Then
-		Return True
-	EndIf
-	Return False
+	If $inventory_management_cache['@pickup.nothing'] Then Return False
+	Local $itemID = DllStructGetData($item, 'ModelID')
+	; Character gold is capped, leave money on the ground when close to the cap
+	If $itemID == $ID_MONEY And GetGoldCharacter() >= 99000 Then Return False
+	Local $decision = GetItemLootDecision($item)
+	If $decision == Null Then Return False
+	Return Not $decision['ignore']
 EndFunc
 
 
 ;~ Return True if the item should be salvaged - default to false
 Func DefaultShouldSalvageItem($item)
-	; Clarity rename
-	Local $cache = $inventory_management_cache
-	If $cache['@salvage.nothing'] Then Return False
-
-	Local $itemID = DllStructGetData($item, 'ModelID')
-	Local $rarity = GetRarity($item)
-	If $rarity == $RARITY_GREEN Then
-		Return False
-	; --------------------------------------- Weapons ---------------------------------------
-	ElseIf IsWeapon($item) Then
-		If Not DllStructGetData($item, 'IsMaterialSalvageable') Then Return False
-		If $cache['@salvage.weapons.nothing'] Then Return False
-		If Not CheckSalvageWeapon($item) Then Return False
-		Return Not ShouldKeepWeapon($item)
-	; --------------------------------- Armor salvageables ---------------------------------
-	ElseIf IsArmorSalvageItem($item) Then
-		If $cache['@salvage.salvageables.nothing'] Then Return False
-		Local $rarityName = $RARITY_NAMES_FROM_IDS[$rarity]
-		If Not $cache['Salvage items.Armor salvageables.' & $rarityName] Then Return False
-		Return IsIdentified($item) And Not ContainsValuableUpgrades($item)
-	; --------------------------------------- Trophies ---------------------------------------
-	ElseIf IsTrophy($itemID) Then
-		If $MAP_FARMED_TROPHIES[$itemID] <> Null Then
-			Local $shouldSalvage = $cache['Salvage items.Trophies.' & $FARMED_TROPHIES_NAMES_FROM_ID[$itemID]]
-			Return $shouldSalvage == Null ? False : $shouldSalvage
-		EndIf
-		; Do not salvage Nick items and items that salvage into rare materials
-		If $MAP_NICHOLAS_ITEMS[$itemID] <> Null Then Return False
-		; - FIXME: salvage once we can salvage with higher salvage kit
-		If $MAP_RARE_MATERIALS_TROPHIES[$itemID] <> Null Then Return False
-		; Salvage items that salvage into feathers, dust, bones and fiber
-		If $MAP_FEATHER_TROPHIES[$itemID] <> Null Then Return True
-		If $MAP_DUST_TROPHIES[$itemID] <> Null Then Return True
-		If $MAP_BONES_TROPHIES[$itemID] <> Null Then Return True
-		If $MAP_FIBER_TROPHIES[$itemID] <> Null Then Return True
-		Return False
-	; -------------------------------------- Materials --------------------------------------
-	ElseIf IsRareMaterial($item) Then
-		Local $materialName = $RARE_MATERIAL_NAMES_FROM_IDS[$itemID]
-		Return $cache['Salvage items.Rare Materials.' & $materialName]
-	EndIf
-	Return False
+	If $inventory_management_cache['@salvage.nothing'] Then Return False
+	If DllStructGetData($item, 'ID') == 0 Then Return False
+	If IsUpgradeComponent($item) Then Return False
+	Local $decision = GetItemLootDecision($item)
+	If $decision == Null Then Return False
+	If $decision['ignore'] Then Return False
+	If $decision['action'] <> $LOOT_ACTION_SALVAGE Then Return False
+	If IsWeapon($item) And Not DllStructGetData($item, 'IsMaterialSalvageable') Then Return False
+	; Items waiting for identification are handled after the identification step
+	If $decision['identify'] And Not IsIdentified($item) Then Return False
+	; Mods worth salvaging come out first with an expert kit - a basic salvage would destroy them
+	If HasComponentsToSalvageOut($item) Then Return False
+	Return True
 EndFunc
 
 
-;~ Return True if valuable components (mods, inscriptions, runes, insignias) should be salvaged out of the item
-;~ Only items not worth keeping for themselves are stripped, so weapons kept for their skin, req or stats stay untouched
+;~ Return True if mods worth salvaging should be taken out of the item: identified, salvageable, and leaving the bags anyway
+;~ Stored items keep their mods, and so do ignored and kept ones
 Func ShouldSalvageComponents($item)
 	If DllStructGetData($item, 'ID') = 0 Then Return False
-	If GetRarity($item) == $RARITY_GREEN Then Return False
 	If Not IsIdentified($item) Then Return False
 	If IsWeapon($item) Then
 		If Not DllStructGetData($item, 'IsMaterialSalvageable') Then Return False
-		If ShouldKeepWeapon($item, False) Then Return False
 	ElseIf Not IsArmorSalvageItem($item) Then
 		Return False
 	EndIf
+	Local $decision = GetItemLootDecision($item)
+	If $decision == Null Then Return False
+	If $decision['ignore'] Then Return False
+	If $decision['action'] <> $LOOT_ACTION_SALVAGE And $decision['action'] <> $LOOT_ACTION_SELL Then Return False
 	Return UBound(GetValuableComponentIndices($item)) > 0
 EndFunc
 
 
 ;~ Return True if the item should be sold to the merchant - default to false
+;~ Materials are sold to the material traders instead, see DefaultShouldSellBasicMaterial and DefaultShouldSellRareMaterial
 Func DefaultShouldSellItem($item)
-	; Clarity rename
-	Local $cache = $inventory_management_cache
-	If $cache['@sell.nothing'] Then Return False
-
-	Local $itemID = DllStructGetData(($item), 'ModelID')
-	Local $rarity = GetRarity($item)
-
-	If DllStructGetData($item, 'Value') == 0 Then
-		Return False
-	ElseIf $rarity == $RARITY_GREEN Then
-		Return False
-	; --------------------------------------- Weapons ---------------------------------------
-	ElseIf IsWeapon($item) Then
-		If $cache['@sell.weapons.nothing'] Then Return False
-		If Not CheckSellWeapon($item) Then Return False
-		Return Not ShouldKeepWeapon($item)
-	; --------------------------------- Armor salvageables ---------------------------------
-	ElseIf isArmorSalvageItem($item) Then
-		If $cache['@sell.salvageables.nothing'] Then Return False
-		Local $rarityName = $RARITY_NAMES_FROM_IDS[$rarity]
-		If Not $cache['Sell items.Armor salvageables.' & $rarityName] Then Return False
-		Return $rarity == $RARITY_WHITE Or (IsIdentified($item) And Not ContainsValuableUpgrades($item))
-	; --------------------------------------- Trophies ---------------------------------------
-	ElseIf IsTrophy($itemID) Then
-		If $MAP_FARMED_TROPHIES[$itemID] <> Null Then
-			Local $shouldSell = $cache['Sell items.Trophies.' & $FARMED_TROPHIES_NAMES_FROM_ID[$itemID]]
-			Return $shouldSell == Null ? False : $shouldSell
-		EndIf
-		; Do not sell Nick items and items that salvage into rare materials
-		If $MAP_NICHOLAS_ITEMS[$itemID] <> Null Then Return False
-		If $MAP_RARE_MATERIALS_TROPHIES[$itemID] <> Null Then Return False
-		; Do not sell items that salvage into feathers, dust, bones and fiber
-		If $MAP_FEATHER_TROPHIES[$itemID] <> Null Then Return False
-		If $MAP_DUST_TROPHIES[$itemID] <> Null Then Return False
-		If $MAP_BONES_TROPHIES[$itemID] <> Null Then Return False
-		If $MAP_FIBER_TROPHIES[$itemID] <> Null Then Return False
-		; Sell the rest
-		Return True
-	; --------------------------------------- Scrolls ---------------------------------------
-	ElseIf IsBlueScroll($itemID) Then
-		Return $cache['Sell items.Scrolls.Blue']
-	ElseIf IsGoldScroll($itemID) Then
-		Local $scrollName = $GOLD_SCROLL_NAMES_FROM_IDS[$itemID]
-		Local $shouldSell = $cache['Sell items.Scrolls.Gold.' & $scrollName]
-		If $shouldSell <> Null Then Return $shouldSell
-		Return $cache['Sell items.Scrolls.Gold.Other gold scrolls']
-	; ----------------------------------------- Keys -----------------------------------------
-	ElseIf IsKey($itemID) Then
-		Return $cache['Sell items.Keys']
-	EndIf
-	Return False
+	If $inventory_management_cache['@sell.nothing'] Then Return False
+	If DllStructGetData($item, 'ID') == 0 Then Return False
+	If DllStructGetData($item, 'Value') == 0 Then Return False
+	If IsMaterial($item) Then Return False
+	If IsUpgradeComponent($item) Then Return ShouldSellLooseComponent($item)
+	Local $decision = GetItemLootDecision($item)
+	If $decision == Null Then Return False
+	If $decision['ignore'] Then Return False
+	If $decision['action'] <> $LOOT_ACTION_SELL Then Return False
+	; Items waiting for identification are handled after the identification step
+	If $decision['identify'] And Not IsIdentified($item) Then Return False
+	; Mods worth salvaging come out first
+	If HasComponentsToSalvageOut($item) Then Return False
+	Return True
 EndFunc
 
 
 ;~ Return True if the item should be stored in Xunlai Storage - default to false
 Func DefaultShouldStoreItem($item)
-	; Clarity rename
-	Local $cache = $inventory_management_cache
-	If $cache['@store.nothing'] Then Return False
-
-	Local $itemID = DllStructGetData(($item), 'ModelID')
-	Local $rarity = GetRarity($item)
-	Local $quantity = DllStructGetData($item, 'Quantity')
-
-	; --------------------------------------- Weapons ---------------------------------------
-	If IsWeapon($item) Then
-		;Return ShouldKeepWeapon($item)
-		Return CheckStoreWeapon($item)
-	; --------------------------------- Armor salvageables ---------------------------------
-	ElseIf isArmorSalvageItem($item) Then
-		Local $rarityName = $RARITY_NAMES_FROM_IDS[$rarity]
-		;Return ContainsValuableUpgrades($item)
-		Return $cache['Store items.Armor salvageables.' & $rarityName]
-	; ----------------------------------- Upgrade components -----------------------------------
-	ElseIf IsUpgradeComponent($item) Then
-		Local $shouldStore = $cache['Store items.Upgrade components']
-		; Loot configurations saved before this option existed have no value for it: store components when the bot salvages them
-		Return $shouldStore == Null ? $run_options_cache['run.salvage_into_components'] : $shouldStore
-	; ------------------------------------- Consumables -------------------------------------
-	ElseIf IsAlcohol($itemID) Then
-		If $MAP_MINOR_ALCOHOLS[$itemID] <> Null Then Return $cache['Store items.Alcohols.Minor (1pt)']
-		If $MAP_MAJOR_ALCOHOLS[$itemID] <> Null Then Return $cache['Store items.Alcohols.Major (3pt)']
-		If $MAP_SUPERIOR_ALCOHOLS[$itemID] <> Null Then Return $cache['Store items.Alcohols.Superior (50pt)']
-		Return False
-	ElseIf IsFestive($itemID) Or IsPartyTonic($itemID) Then
-		If $MAP_MINOR_PARTY[$itemID] <> Null Then Return $cache['Store items.Party.Minor (1-2pt)']
-		If $MAP_MAJOR_PARTY[$itemID] <> Null Then Return $cache['Store items.Party.Major (3-7pt)']
-		If $MAP_SUPERIOR_PARTY[$itemID] <> Null Then Return $cache['Store items.Party.Superior (25-50pt)']
-		Return False
-	ElseIf IsTownSweet($itemID) Then
-		If $MAP_MINOR_SWEETS[$itemID] <> Null Then Return $cache['Store items.Sweets.Minor (1-2pt)']
-		If $MAP_MAJOR_SWEETS[$itemID] <> Null Then Return $cache['Store items.Sweets.Major (3pt)']
-		If $MAP_SUPERIOR_SWEETS[$itemID] <> Null Then Return $cache['Store items.Sweets.Superior (50pt)']
-		Return False
-	ElseIf IsPCon($itemID) Then
-		Local $pconName = $PCONS_NAMES_FROM_IDS[$itemID]
-		Return $cache['Store items.PCons.' & $pconName]
-	ElseIf IsDPRemoval($itemID) Then
-		Local $moraleItemName = $DP_REMOVAL_NAMES_FROM_IDS[$itemID]
-		Return $cache['Store items.Morale.' & $moraleItemName]
-	ElseIf IsSpecialDrop($itemID) Then
-		Local $specialDropName = $SPECIAL_DROP_NAMES_FROM_IDS[$itemID]
-		Return $cache['Store items.Special drops.' & $specialDropName]
-	ElseIf IsSummoningStone($itemID) Then
-		Local $stoneName = $SUMMONING_STONES_NAMES_FROM_IDS[$itemID]
-		Return $cache['Store items.Summoning stones.' & $stoneName]
-	ElseIf IsConset($itemID) Then
-		Local $consetItemName = $MAP_CONSETS[$itemID]
-		Return $cache['Store items.Consets.' & $consetItemName]
-	ElseIf IsConsumable($itemID) Then
-		Return $cache['Store items.Consumables']
-	; --------------------------------------- Trophies ---------------------------------------
-	ElseIf IsTrophy($itemID) Then
-		If $MAP_FARMED_TROPHIES[$itemID] <> Null Then Return $cache['Store items.Trophies.' & $FARMED_TROPHIES_NAMES_FROM_ID[$itemID]]
-		If $quantity <> 250 Then Return False
-		Return True
-	; -------------------------------------- Materials --------------------------------------
-	ElseIf IsBasicMaterial($item) Then
-		Local $materialName = $BASIC_MATERIAL_NAMES_FROM_IDS[$itemID]
-		Return $cache['Store items.Basic Materials.' & $materialName]
-	ElseIf IsRareMaterial($item) Then
-		Local $materialName = $RARE_MATERIAL_NAMES_FROM_IDS[$itemID]
-		Return $cache['Store items.Rare Materials.' & $materialName]
-	; ----------------------------------------- Tomes -----------------------------------------
-	ElseIf IsRegularTome($itemID) Then
-		Local $tomeName = $REGULAR_TOME_NAMES_FROM_IDS[$itemID]
-		Return $cache['Store items.Tomes.Normal.' & $tomeName]
-	ElseIf IsEliteTome($itemID) Then
-		Local $tomeName = $ELITE_TOME_NAMES_FROM_IDS[$itemID]
-		Return $cache['Store items.Tomes.Elite.' & $tomeName]
-	; --------------------------------------- Scrolls ---------------------------------------
-	ElseIf IsGoldScroll($itemID) Then
-		Local $scrollName = $GOLD_SCROLL_NAMES_FROM_IDS[$itemID]
-		Local $shouldStore = $cache['Store items.Scrolls.Gold.' & $scrollName]
-		If $shouldStore <> Null Then Return $shouldStore
-		Return $cache['Store items.Scrolls.Gold.Other gold scrolls']
-	ElseIf IsBlueScroll($itemID) Then
-		Return $cache['Store items.Scrolls.Blue']
-	; ----------------------------------------- Keys -----------------------------------------
-	ElseIf IsKey($itemID) Then
-		Return $cache['Store items.Keys']
-	; ----------------------------------------- Dyes -----------------------------------------
-	ElseIf ($itemID == $ID_DYES) Then
-		Local $dyeColorID = DllStructGetData($item, 'DyeColor')
-		Local $dyeColorName = $DYE_NAMES_FROM_IDS[$dyeColorID]
-		Return $cache['Store items.Dyes.' & $dyeColorName]
-	EndIf
-	Return False
-EndFunc
-
-
-;~ Return True if weapon item should not be sold or salvaged - $checkUpgrades False ignores the components it contains
-Func ShouldKeepWeapon($item, $checkUpgrades = True)
-	Local Static $lowReqValuableWeaponTypes = [$ID_TYPE_SWORD, $ID_TYPE_OFFHAND, $ID_TYPE_SHIELD, $ID_TYPE_DAGGER, $ID_TYPE_SCYTHE, $ID_TYPE_SPEAR]
-	Local Static $lowReqValuableWeaponTypesMap = MapFromArray($lowReqValuableWeaponTypes)
-	Local Static $valuableOSWeaponTypes = [$ID_TYPE_SHIELD, $ID_TYPE_OFFHAND, $ID_TYPE_WAND]
-	Local Static $valuableOSWeaponTypesMap = MapFromArray($valuableOSWeaponTypes)
-
-	Local $rarity = GetRarity($item)
-	Local $itemID = DllStructGetData($item, 'ModelID')
-	Local $type = DllStructGetData($item, 'Type')
-	; Keeping equipped items
-	If DllStructGetData($item, 'Equipped') Then Return True
-	; Keeping customized items
-	If DllStructGetData($item, 'Customized') <> 0 Then Return True
-	; Throwing white items
-	If $rarity == $RARITY_WHITE Then Return False
-	; Keeping green items
-	If $rarity == $RARITY_GREEN Then Return True
-	; Keeping unidentified items
-	If Not IsIdentified($item) Then Return True
-	; Keeping super-rare items, good in all cases, items (BDS, voltaic, etc)
-	If $MAP_ULTRA_RARE_WEAPONS[$itemID] <> Null Then Return True
-	; Keeping items that contain good upgrades
-	If $checkUpgrades And ContainsValuableUpgrades($item) Then Return True
-	; Throwing items without good damage/energy/armor
-	If Not IsMaxStatsForReq($item) Then Return False
-	; Inscribable are kept only if : 1) rare skin and q9 2) low Req of a good type
-	If IsInscribable($item) Then
-		If IsLowReqMaxStats($item) And $lowReqValuableWeaponTypesMap[DllStructGetData($item, 'type')] <> Null Then Return True
-		If GetItemReq($item) == 9 And $MAP_RARE_WEAPONS[$itemID] <> Null Then Return True
-		Return False
-	; OS - Old School weapon without inscription ... it is more complicated
-	Else
-		If GetItemReq($item) >= 9 Then
-			; OS (Old School) high Req are kept only if : 1) rare skin and perfect mods 2) good type and perfect mods (shield, offhand, wand)
-			If $MAP_RARE_WEAPONS[$itemID] <> Null Then
-				Return HasPerfectMods($item)
-			ElseIf $valuableOSWeaponTypesMap[DllStructGetData($item, 'type')] <> Null Then
-				Return HasPerfectMods($item)
-			EndIf
-			Return False
-		Else
-			; Low Req are kept if they have perfect mods
-			If HasPerfectMods($item) Then Return True
-			If $MAP_RARE_WEAPONS[$itemID] <> Null And HasPerfectMods($item) Then Return True
-			Return False
-		EndIf
-	EndIf
-	Return False
+	If $inventory_management_cache['@store.nothing'] Then Return False
+	If DllStructGetData($item, 'ID') == 0 Then Return False
+	If IsUpgradeComponent($item) Then Return ShouldStoreLooseComponent($item)
+	Local $decision = GetItemLootDecision($item)
+	If $decision == Null Then Return False
+	If $decision['ignore'] Then Return False
+	Return $decision['action'] == $LOOT_ACTION_STORE
 EndFunc
 
 
 ;~ Return true if basic material should be sold to the material merchant
 Func DefaultShouldSellBasicMaterial($item)
 	If Not IsBasicMaterial($item) Then Return False
-	Local $materialID = DllStructGetData($item, 'ModelID')
-	Local $materialName = $BASIC_MATERIAL_NAMES_FROM_IDS[$materialID]
-	Return $inventory_management_cache['Sell items.Basic Materials.' & $materialName]
+	Local $decision = GetItemLootDecision($item)
+	If $decision == Null Then Return False
+	If $decision['ignore'] Then Return False
+	Return $decision['action'] == $LOOT_ACTION_SELL
 EndFunc
 
 
 ;~ Return true if rare material should be sold to the rare material merchant
 Func DefaultShouldSellRareMaterial($item)
 	If Not IsRareMaterial($item) Then Return False
-	Local $materialID = DllStructGetData($item, 'ModelID')
-	Local $materialName = $RARE_MATERIAL_NAMES_FROM_IDS[$materialID]
-	Return $inventory_management_cache['Sell items.Rare Materials.' & $materialName]
+	Local $decision = GetItemLootDecision($item)
+	If $decision == Null Then Return False
+	If $decision['ignore'] Then Return False
+	Return $decision['action'] == $LOOT_ACTION_SELL
 EndFunc
 
 
-;~ Return true if a weapon should be picked up
-Func CheckPickupWeapon($weaponItem)
-	Local $weaponRarity = GetRarity($weaponItem)
-	If $weaponRarity == $RARITY_RED Then Return True
-	If $weaponRarity == $RARITY_GRAY Then Return False
-	If $weaponRarity <> $RARITY_WHITE And IsLowReqMaxStats($weaponItem) And $inventory_management_cache['Pick up items.Weapons and offhands.Low Req Max Stats'] Then Return True
-	Local $itemID = DllStructGetData($weaponItem, 'ModelID')
-	If $weaponRarity <> $RARITY_WHITE And $RARE_WEAPONS_TO_PICK[$itemID] <> Null And IsMaxStatsForReq($weaponItem) Then Return True
-
-	Local $weaponRarityName = $RARITY_NAMES_FROM_IDS[$weaponRarity]
-	Local $weaponType = DllStructGetData($weaponItem, 'Type')
-	Local $weaponTypeName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
-	Local $weaponReq = GetItemReq($weaponItem)
-	Return $inventory_management_cache['Pick up items.Weapons and offhands.' & $weaponRarityName & '.' & $weaponTypeName & '.Req ' & $weaponReq]
-EndFunc
-
-
-Func CheckSalvageWeapon($weaponItem)
-	Local $weaponRarity = GetRarity($weaponItem)
-	If $weaponRarity == $RARITY_GREEN Or $weaponRarity == $RARITY_GRAY Or $weaponRarity == $RARITY_RED Then Return False
-	Local $weaponRarityName = $RARITY_NAMES_FROM_IDS[$weaponRarity]
-	Local $weaponType = DllStructGetData($weaponItem, 'Type')
-	Local $weaponTypeName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
-	Local $weaponReq = GetItemReq($weaponItem)
-	Return $inventory_management_cache['Salvage items.Weapons and offhands.' & $weaponRarityName & '.' & $weaponTypeName & '.Req ' & $weaponReq]
-EndFunc
-
-
-Func CheckSellWeapon($weaponItem)
-	Local $weaponRarity = GetRarity($weaponItem)
-	If $weaponRarity == $RARITY_GREEN Or $weaponRarity == $RARITY_GRAY Or $weaponRarity == $RARITY_RED Then Return False
-	Local $weaponRarityName = $RARITY_NAMES_FROM_IDS[$weaponRarity]
-	Local $weaponType = DllStructGetData($weaponItem, 'Type')
-	Local $weaponTypeName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
-	Local $weaponReq = GetItemReq($weaponItem)
-	Return $inventory_management_cache['Sell items.Weapons and offhands.' & $weaponRarityName & '.' & $weaponTypeName & '.Req ' & $weaponReq]
-EndFunc
-
-
-Func CheckStoreWeapon($weaponItem)
-	Local $weaponRarity = GetRarity($weaponItem)
-	If $weaponRarity == $RARITY_GRAY Or $weaponRarity == $RARITY_RED Then Return False
-	Local $weaponRarityName = $RARITY_NAMES_FROM_IDS[$weaponRarity]
-	Local $weaponType = DllStructGetData($weaponItem, 'Type')
-	Local $weaponTypeName = $WEAPON_NAMES_FROM_TYPES[$weaponType]
-	Local $weaponReq = GetItemReq($weaponItem)
-	Return $inventory_management_cache['Store items.Weapons and offhands.' & $weaponRarityName & '.' & $weaponTypeName & '.Req ' & $weaponReq]
-EndFunc
 #EndRegion Inventory Management
 
 
@@ -1073,7 +737,7 @@ Func BuyKitsForMidRun()
 	If $salvageKitsRequired > 0 Then BuySalvageKitInTown($salvageKitsRequired)
 	If $identificationKitsRequired > 0 Then BuySuperiorIdentificationKitInTown($identificationKitsRequired)
 	; Salvaging components needs an expert salvage kit - keep one in inventory when the option is enabled
-	If $run_options_cache['run.salvage_into_components'] And FindSalvageKit() == Null Then BuyExpertSalvageKitInTown()
+	If $inventory_management_cache['@components.something'] And FindSalvageKit() == Null Then BuyExpertSalvageKitInTown()
 EndFunc
 #EndRegion Buying/selling items from/to merchant
 
@@ -1220,7 +884,7 @@ EndFunc
 
 
 #Region Identification
-;~ Identify items from inventory
+;~ Identifies the items whose leaf asks for identification, buying superior kits in town when allowed
 Func IdentifyItems($buyKit = True)
 	Info('Identifying items')
 	For $bagIndex = 1 To $bags_count
@@ -1229,22 +893,17 @@ Func IdentifyItems($buyKit = True)
 		For $i = 1 To DllStructGetData($bag, 'slots')
 			$item = GetItemBySlot($bagIndex, $i)
 			If DllStructGetData($item, 'ID') == 0 Then ContinueLoop
-			If Not IsIdentified($item) Then
-				Local $rarity = GetRarity($item)
-				Local $rarityName = $RARITY_NAMES_FROM_IDS[$rarity]
-				If Not $inventory_management_cache['Identify items.' & $rarityName] Then ContinueLoop
-
-				Local $identificationKit = FindIdentificationKit()
-				If $identificationKit == Null Then
-					If $buyKit Then
-						BuySuperiorIdentificationKitInTown()
-					Else
-						Return False
-					EndIf
+			If Not ShouldIdentifyItem($item) Then ContinueLoop
+			Local $identificationKit = FindIdentificationKit()
+			If $identificationKit == Null Then
+				If $buyKit Then
+					BuySuperiorIdentificationKitInTown()
+				Else
+					Return False
 				EndIf
-				IdentifyItem($item)
-				RandomSleep(100)
 			EndIf
+			IdentifyItem($item)
+			RandomSleep(100)
 		Next
 	Next
 	Return True
@@ -3087,4 +2746,235 @@ Func AutomaticTonicConsumer()
 		Next
 	WEnd
 	Return $PAUSE
+EndFunc
+
+
+;~ Configuration path of the leaf holding the decision for an item - Null for items without a leaf (loose mods, jars)
+;~ Unknown items fall back to the Other items leaves in GetItemLootDecision
+Func GetItemLootPath($item)
+	Local $itemID = DllStructGetData($item, 'ModelID')
+	Local $items = $LOOT_ROOT_ITEMS & '.'
+	; ---------------------------------------- Money ----------------------------------------
+	If $itemID == $ID_MONEY Then Return $items & $LOOT_MONEY
+	; --------------------------------------- Weapons ---------------------------------------
+	If IsWeapon($item) Then Return GetWeaponLootPath($item)
+	; --------------------------------- Armor salvageables ---------------------------------
+	If IsArmorSalvageItem($item) Then Return $items & $LOOT_ARMOR_FAMILY & '.' & $RARITY_NAMES_FROM_IDS[GetRarity($item)]
+	; --------------------------- Consumables, Alcohols, Party & Sweets ---------------------------
+	If IsAlcohol($itemID) Then
+		If $MAP_MINOR_ALCOHOLS[$itemID] <> Null Then Return $items & 'Alcohols.Minor (1pt)'
+		If $MAP_MAJOR_ALCOHOLS[$itemID] <> Null Then Return $items & 'Alcohols.Major (3pt)'
+		If $MAP_SUPERIOR_ALCOHOLS[$itemID] <> Null Then Return $items & 'Alcohols.Superior (50pt)'
+		Return Null
+	EndIf
+	If IsFestive($itemID) Or IsPartyTonic($itemID) Then
+		If $MAP_MINOR_PARTY[$itemID] <> Null Then Return $items & 'Party.Minor (1-2pt)'
+		If $MAP_MAJOR_PARTY[$itemID] <> Null Then Return $items & 'Party.Major (3-7pt)'
+		If $MAP_SUPERIOR_PARTY[$itemID] <> Null Then Return $items & 'Party.Superior (25-50pt)'
+		Return Null
+	EndIf
+	If IsTownSweet($itemID) Then
+		If $MAP_MINOR_SWEETS[$itemID] <> Null Then Return $items & 'Sweets.Minor (1-2pt)'
+		If $MAP_MAJOR_SWEETS[$itemID] <> Null Then Return $items & 'Sweets.Major (3pt)'
+		If $MAP_SUPERIOR_SWEETS[$itemID] <> Null Then Return $items & 'Sweets.Superior (50pt)'
+		Return Null
+	EndIf
+	If IsPCon($itemID) Then Return $items & 'PCons.' & $PCONS_NAMES_FROM_IDS[$itemID]
+	If IsDPRemoval($itemID) Then Return $items & 'Morale.' & $DP_REMOVAL_NAMES_FROM_IDS[$itemID]
+	If IsSpecialDrop($itemID) Then Return $items & 'Special drops.' & $SPECIAL_DROP_NAMES_FROM_IDS[$itemID]
+	If IsSummoningStone($itemID) Then Return $items & 'Summoning stones.' & $SUMMONING_STONES_NAMES_FROM_IDS[$itemID]
+	If IsConset($itemID) Then Return $items & 'Consets.' & $MAP_CONSETS[$itemID]
+	If IsConsumable($itemID) Then Return $items & $LOOT_CONSUMABLES
+	; --------------------------------------- Trophies ---------------------------------------
+	If IsTrophy($itemID) Then Return GetTrophyLootPath($itemID)
+	; -------------------------------------- Materials --------------------------------------
+	If IsBasicMaterial($item) Then Return $items & $LOOT_BASIC_MATERIALS_FAMILY & '.' & $BASIC_MATERIAL_NAMES_FROM_IDS[$itemID]
+	If IsRareMaterial($item) Then Return $items & $LOOT_RARE_MATERIALS_FAMILY & '.' & $RARE_MATERIAL_NAMES_FROM_IDS[$itemID]
+	; ---------------------------------------- Tomes ----------------------------------------
+	If IsRegularTome($itemID) Then Return $items & 'Tomes.Normal.' & $REGULAR_TOME_NAMES_FROM_IDS[$itemID]
+	If IsEliteTome($itemID) Then Return $items & 'Tomes.Elite.' & $ELITE_TOME_NAMES_FROM_IDS[$itemID]
+	; --------------------------------------- Scrolls ---------------------------------------
+	If IsGoldScroll($itemID) Then
+		Local $scrollPath = $items & $LOOT_SCROLLS_FAMILY & '.Gold.' & $GOLD_SCROLL_NAMES_FROM_IDS[$itemID]
+		If LootLeafExists($scrollPath) Then Return $scrollPath
+		Return $items & $LOOT_SCROLLS_FAMILY & '.Gold.' & $LOOT_OTHER_GOLD_SCROLLS
+	EndIf
+	If IsBlueScroll($itemID) Then Return $items & $LOOT_SCROLLS_FAMILY & '.Blue'
+	; ------------------------------------ Keys & Dyes ------------------------------------
+	If IsKey($itemID) Then Return $items & 'Keys'
+	If $itemID == $ID_LOCKPICK Then Return $items & 'Lockpicks'
+	If $itemID == $ID_DYES Then Return $items & 'Dyes.' & $DYE_NAMES_FROM_IDS[DllStructGetData($item, 'DyeColor')]
+	; --------------------------------- Gizmos & Quest items ---------------------------------
+	If $itemID == $ID_JAR_OF_INVIGORATION Then Return Null
+	If IsMapPiece($itemID) Then Return $items & 'Quest items.Map pieces'
+	If IsMiniature($item) Then Return $items & 'Miniatures'
+	; Loose mods, inscriptions, runes and insignias follow the Mods section
+	If IsUpgradeComponent($item) Then Return Null
+	Return $items & $LOOT_OTHER_FAMILY & '.' & (IsStackable($item) ? $LOOT_OTHER_STACKABLES : $LOOT_OTHER_UNKNOWN)
+EndFunc
+
+
+;~ Configuration path of a weapon: type > rarity > requirement > rare or other skins, green weapons having a single leaf per type
+Func GetWeaponLootPath($item)
+	Local $weapons = $LOOT_ROOT_ITEMS & '.' & $LOOT_WEAPONS_FAMILY & '.'
+	Local $typeName = $WEAPON_NAMES_FROM_TYPES[DllStructGetData($item, 'Type')]
+	If $typeName == Null Then Return Null
+	Local $rarity = GetRarity($item)
+	If $rarity == $RARITY_GREEN Then Return $weapons & $typeName & '.' & $LOOT_GREEN_RARITY
+	Local $rarityName = $RARITY_NAMES_FROM_IDS[$rarity]
+	; Gray named weapons are trash like white ones, red ones are not weapons the configuration knows
+	If $rarity == $RARITY_GRAY Then $rarityName = 'White'
+	If $rarity == $RARITY_RED Or $rarityName == Null Then Return Null
+	Local $req = GetItemReq($item)
+	If $req < 0 Then $req = 0
+	If $req > $LOOT_WEAPON_MAX_REQ Then $req = $LOOT_WEAPON_MAX_REQ
+	Local $skins = IsRareSkinWeapon($item) ? $LOOT_RARE_SKINS : $LOOT_OTHER_SKINS
+	Return $weapons & $typeName & '.' & $rarityName & '.Req ' & $req & '.' & $skins
+EndFunc
+
+
+;~ Configuration path of a trophy: farmed trophies have their own leaf, the others are grouped by what they are worth
+Func GetTrophyLootPath($itemID)
+	Local $trophies = $LOOT_ROOT_ITEMS & '.' & $LOOT_TROPHIES_FAMILY & '.'
+	If $MAP_FARMED_TROPHIES[$itemID] <> Null Then
+		Local $farmedPath = $trophies & $FARMED_TROPHIES_NAMES_FROM_ID[$itemID]
+		If LootLeafExists($farmedPath) Then Return $farmedPath
+	EndIf
+	If $MAP_NICHOLAS_ITEMS[$itemID] <> Null Then Return $trophies & $LOOT_TROPHIES_NICHOLAS
+	If $MAP_RARE_MATERIALS_TROPHIES[$itemID] <> Null Then Return $trophies & $LOOT_TROPHIES_RARE_MATERIALS
+	If $MAP_FEATHER_TROPHIES[$itemID] <> Null Then Return $trophies & $LOOT_TROPHIES_COMMON_MATERIALS
+	If $MAP_DUST_TROPHIES[$itemID] <> Null Then Return $trophies & $LOOT_TROPHIES_COMMON_MATERIALS
+	If $MAP_BONES_TROPHIES[$itemID] <> Null Then Return $trophies & $LOOT_TROPHIES_COMMON_MATERIALS
+	If $MAP_FIBER_TROPHIES[$itemID] <> Null Then Return $trophies & $LOOT_TROPHIES_COMMON_MATERIALS
+	Return $trophies & $LOOT_TROPHIES_OTHER
+EndFunc
+
+
+;~ Rare skins get their own leaf under each requirement: weapons of the rare and ultra rare lists with max stats for their requirement
+Func IsRareSkinWeapon($item)
+	Local $itemID = DllStructGetData($item, 'ModelID')
+	Local $rareSkin = $MAP_RARE_WEAPONS[$itemID] <> Null
+	If $RARE_WEAPONS_TO_PICK[$itemID] <> Null Then $rareSkin = True
+	If $MAP_ULTRA_RARE_WEAPONS[$itemID] <> Null Then $rareSkin = True
+	If Not $rareSkin Then Return False
+	Return IsMaxStatsForReq($item)
+EndFunc
+
+
+;~ Decision for an item: map with keys ignore, identify and action - Null when the configuration has no leaf at all for it
+;~ Items without a leaf of their own follow the Other items leaves (stackables or unknown items)
+;~ Weapons then go through the weapon rules: equipped and customized weapons are never touched, the low requirement
+;~ rule replaces the leaf, and weapons worth keeping are stored instead of being salvaged or sold
+Func GetItemLootDecision($item)
+	Local $path = GetItemLootPath($item)
+	Local $decision = Null
+	If $path <> Null Then $decision = GetLootItemDecision($path)
+	If $decision == Null Then
+		Local $fallback = $LOOT_ROOT_ITEMS & '.' & $LOOT_OTHER_FAMILY & '.' & (IsStackable($item) ? $LOOT_OTHER_STACKABLES : $LOOT_OTHER_UNKNOWN)
+		$decision = GetLootItemDecision($fallback)
+		If $decision == Null Then Return Null
+	EndIf
+	If Not IsWeapon($item) Then Return $decision
+	Return ApplyWeaponLootRules($item, $decision)
+EndFunc
+
+
+;~ Weapon rules on top of the leaf decision - see GetItemLootDecision
+Func ApplyWeaponLootRules($item, $decision)
+	; Equipped and customized weapons belong to the character
+	If DllStructGetData($item, 'Equipped') Or DllStructGetData($item, 'Customized') <> 0 Then
+		$decision['ignore'] = True
+		Return $decision
+	EndIf
+	; The low requirement rule applies to any non white weapon with max stats and a requirement under 9
+	Local $rarity = GetRarity($item)
+	If $rarity <> $RARITY_WHITE And $rarity <> $RARITY_GRAY Then
+		If IsLowReqMaxStats($item) Then
+			Local $rule = GetLootItemDecision($LOOT_ROOT_ITEMS & '.' & $LOOT_WEAPONS_FAMILY & '.' & $LOOT_LOW_REQ_RULE)
+			If $rule <> Null Then
+				If Not $rule['ignore'] Then $decision = $rule
+			EndIf
+		EndIf
+	EndIf
+	If $decision['ignore'] Then Return $decision
+	; Weapons worth keeping are stored whatever the leaf says
+	If $decision['action'] == $LOOT_ACTION_SALVAGE Or $decision['action'] == $LOOT_ACTION_SELL Then
+		If IsWeaponWorthKeeping($item) Then $decision['action'] = $LOOT_ACTION_STORE
+	EndIf
+	Return $decision
+EndFunc
+
+
+;~ Keep rules: ultra rare skins, and identified old school weapons with max stats and perfect inherent mods
+Func IsWeaponWorthKeeping($item)
+	Local $itemID = DllStructGetData($item, 'ModelID')
+	If $MAP_ULTRA_RARE_WEAPONS[$itemID] <> Null Then Return True
+	If Not IsIdentified($item) Then Return False
+	If IsInscribable($item) Then Return False
+	If Not IsMaxStatsForReq($item) Then Return False
+	Return HasPerfectMods($item)
+EndFunc
+
+
+;~ Return True if the item should be identified: not identified yet, not ignored, and its leaf asks for identification
+Func ShouldIdentifyItem($item)
+	If DllStructGetData($item, 'ID') == 0 Then Return False
+	If IsIdentified($item) Then Return False
+	Local $decision = GetItemLootDecision($item)
+	If $decision == Null Then Return False
+	If $decision['ignore'] Then Return False
+	Return $decision['identify']
+EndFunc
+
+
+;~ Returns true if there are items in inventory waiting for identification
+Func HasItemsToIdentify()
+	Return HasInInventory(ShouldIdentifyItem)
+EndFunc
+
+
+;~ True when the configuration asks to keep the character gold balanced with the Xunlai storage
+Func IsMoneyStored()
+	Local $decision = GetLootItemDecision($LOOT_ROOT_ITEMS & '.' & $LOOT_MONEY)
+	If $decision == Null Then Return False
+	If $decision['ignore'] Then Return False
+	Return $decision['action'] == $LOOT_ACTION_STORE
+EndFunc
+
+
+;~ True when mods worth salvaging are still on the item - such an item waits for SalvageComponents before anything else happens to it
+Func HasComponentsToSalvageOut($item)
+	If $inventory_management_cache['@components.nothing'] Then Return False
+	If Not IsIdentified($item) Then Return False
+	If Not IsWeapon($item) And Not IsArmorSalvageItem($item) Then Return False
+	Return UBound(GetValuableComponentIndices($item)) > 0
+EndFunc
+
+
+;~ Decision of a loose mod, inscription, rune or insignia from the Mods section - Null when it is not listed there
+Func GetLooseComponentDecision($item)
+	Local $modStruct = GetModStruct($item)
+	If Not $modStruct Then Return Null
+	For $struct In MapKeys($component_decisions_by_struct)
+		If StringInStr($modStruct, $struct) > 0 Then Return $component_decisions_by_struct[$struct]
+	Next
+	Return Null
+EndFunc
+
+
+;~ Loose components are stored when their mod is salvaged and stored
+Func ShouldStoreLooseComponent($item)
+	Local $decision = GetLooseComponentDecision($item)
+	If $decision == Null Then Return False
+	If Not $decision['salvage'] Then Return False
+	Return $decision['store']
+EndFunc
+
+
+;~ Loose components are sold when their mod is salvaged but not stored
+Func ShouldSellLooseComponent($item)
+	Local $decision = GetLooseComponentDecision($item)
+	If $decision == Null Then Return False
+	If Not $decision['salvage'] Then Return False
+	Return Not $decision['store']
 EndFunc

--- a/src/utilities/TestSuite.au3
+++ b/src/utilities/TestSuite.au3
@@ -40,6 +40,7 @@ Global Const $HERO_TO_ADD = $ID_HAYDA
 ;~ Main method from utils, used only to run tests
 Func RunTests()
 	;SellItemsToMerchant(DefaultShouldSellItem, True)
+	;SalvageComponents(False, True)
 
 	; To run some mapping, uncomment the following line, and set the path to the file that will contain the mapping
 	;ToggleMapping(1, @ScriptDir & '/logs/fow_mapping.log')


### PR DESCRIPTION
## Summary

Stacked on #231 and #230: their commits are included here until they merge, so this branch is also a complete build for testing all three features together.

The Inventory tab used to be organised by action (Pick up, Identify, Salvage, Sell, Store, Keep components), so the fate of one item was spread across five trees. It is now organised by item, with one decision per leaf, and the window grew from 650x500 to 900x650 to fit a decision panel next to the tree.

### Configuration format

`conf/loot/*.json` now has three roots. `Items` leaves hold one string: `ignore`, or `[identify+]keep|salvage|sell|store`. `Mods` leaves (weapon mods, inscriptions, runes, insignias) hold `ignore`, `salvage+store` or `salvage+sell`. `Buy items` is unchanged. Files in the previous format are migrated when loaded (`MigrateLootConfigurationV1`): an item is ignored when it was not picked up, salvage wins over sell which wins over store when several were ticked, identification follows the former per rarity setting, kept components become salvaged and stored. Saving writes the new format. The shipped default configuration is the migration of the previous one.

New library `lib/Utils-Loot_Configuration.au3` (no game dependency): load, migrate, save, decision parsing, group flags and the derived `@action.family.something` flags, which now live there instead of BotsHub.au3.

### Item tree

- Weapons: type > rarity (White, Blue, Purple, Gold) > requirement 0-13 > `Rare skins` / `Other skins`, plus one `Green` leaf per type and a `Low req max stats` rule leaf. Rare skins are the existing rare and ultra rare lists, when the weapon has max stats for its requirement.
- Trophies: farmed trophies keep their leaf; the rest is split into `Common material trophies`, `Nicholas trophies`, `Rare material trophies` and `Other trophies` instead of the former hard coded rules.
- `Other items`: `Stackables` and `Unknown items` give a decision to everything the classifier does not know.
- Money, armor salvageables, materials, consumables, tomes, scrolls, dyes, keys, lockpicks, miniatures and quest items keep their entries.

### Bot behaviour

- `GetItemLootPath` / `GetItemLootDecision` in Utils-Storage.au3 classify an item and read its decision; `DefaultShouldPickItem`, `ShouldIdentifyItem`, `DefaultShouldSalvageItem`, `DefaultShouldSellItem`, `DefaultShouldStoreItem` and the material sellers use it. Identification is per item instead of per rarity; the "store unidentified gold items" step is replaced by leaves with `store` and no `identify`.
- Weapon rules: equipped and customized items are never touched; the low req max stats leaf replaces the leaf of such weapons; ultra rare skins and identified old school weapons with max stats and perfect mods are stored instead of salvaged or sold (`IsWeaponWorthKeeping`). `ShouldKeepWeapon` and the four `Check*Weapon` helpers are gone.
- Mods: `ShouldSalvageComponents` only strips items whose decision is salvage or sell, so stored items keep their mods. A mod flagged `salvage+sell` is sold after extraction, `salvage+store` is stored (`GetLooseComponentDecision`). Items still carrying mods to extract wait for `SalvageComponents` before being salvaged or sold. The `Salvage into components` run option from #230 is removed: the Mods section is the single switch.
- Materials are never sold to the regular merchant, only to the traders.

### GUI

Tree on the left with checkboxes meaning picked up / salvaged / bought (ticking a group ticks everything below), decision panel on the right for the selected node: Ignore, Identify, then Keep / Salvage / Sell / Store, or the two mod checkboxes, or Buy. Ignore disables the other options. A change on a group applies to every leaf below it; rows show their decision in brackets and groups show `[mixed]`. Load, Save, Apply, Expand and Reduce behave as before; the old tree helpers are removed.

### Documentation

`doc/rare-skins.md` lists, per weapon type, the skins counted as rare and as ultra rare, generated from the ID tables in `lib/GWA2_ID_Items.au3`. The README and the panel legend link to it. The footer (character, farm, Start, progress) sits at the bottom of the taller window and uses its width.

### Notes

- Migration reproduces what the bot actually did, not what the ticks looked like: a weapon ticked for both Sell and Store was sold, so it migrates to `sell`.
- Red named weapons have no leaf and follow `Unknown items` (ignored by default); they used to be picked up and then left in the bags.
- Old configurations gain `Other items` with stackables picked up and kept, unknown items ignored, matching the previous behaviour.

## Test plan

- [x] Au3Check on BotsHub.au3: same 44 pre-existing errors as master, one warning fewer
- [x] Headless AutoIt test of the library: migration of the default configuration (2005 leaves), save and reload round trip identical, group flags and derived flags checked
- [ ] Open the Inventory tab: tree builds, selecting leaves and groups shows their decision, panel changes update rows and checkboxes, Apply then Save writes the new format
- [ ] Load a loot file in the old format and check the migration log line and the resulting tree
- [ ] Run a farm: pick up follows the tree, identification per item, mods extracted only from salvaged or sold items, loose mods stored or sold, weapons kept by the rules are stored
- [ ] Vanquish with a mixed bag of drops and compare the town pass with the previous behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)
